### PR TITLE
ci: consolidate preflight check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,18 +14,25 @@ jobs:
     runs-on: ubuntu-latest
     name: Preflight checks
     outputs:
-      be_changed: ${{ steps.be-changes.outputs.be_changed }}
-      fe_changed: ${{ steps.fe-changes.outputs.fe_changed }}
+      be_changed: ${{ steps.change-check.outputs.be_changed }}
+      fe_changed: ${{ steps.change-check.outputs.fe_changed }}
     steps:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0 
-      - name: Change check (frontend)
-        id: fe-changes
+      - name: Change check
+        id: change-check
         run: |
-          if [ "${{ github.ref }}" == "refs/heads/main" ] | [ -n "$(git diff --name-only origin/main origin/${GITHUB_HEAD_REF} -- ./.github)" ]
+          if [ "${{ github.ref }}" == "refs/heads/main" ]
           then
             echo "fe_changed=true" >> "$GITHUB_OUTPUT"
+            echo "be_changed=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [ -n "$(git diff --name-only origin/main origin/${GITHUB_HEAD_REF} -- ./.github)" ]
+          then
+            echo "fe_changed=true" >> "$GITHUB_OUTPUT"
+            echo "be_changed=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           git diff --name-only origin/main origin/${GITHUB_HEAD_REF} -- ./frontend
@@ -33,15 +40,6 @@ jobs:
           then
             echo "fe_changed=true" >> "$GITHUB_OUTPUT"
           fi
-      - name: Change check (backend)
-        id: be-changes
-        run: |
-          if [ "${{ github.ref }}" == "refs/heads/main" ] | [ -n "$(git diff --name-only origin/main origin/${GITHUB_HEAD_REF} -- ./.github)" ]
-          then
-            echo "be_changed=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          git diff --name-only origin/main origin/${GITHUB_HEAD_REF} -- ./backend
           if [ -n "$(git diff --name-only origin/main origin/${GITHUB_HEAD_REF} -- ./backend)" ]
           then
             echo "be_changed=true" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
The preflight check controls what parts of CI runs and when. This includes running all CI if CI files are edited or if running on `main`.

This simplifies the bash block run to determine what is run so it's a single unit.