### PR TITLE
build(backend): test tooling setup + taskfile tidy

### DIFF
--- a/.github/workflows/backend-pipeline.yml
+++ b/.github/workflows/backend-pipeline.yml
@@ -52,3 +52,28 @@ jobs:
         run: |
           . script/bootstrap
           black . --check
+  test:
+    runs-on: ubuntu-latest
+    name: Test
+    needs: setup
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - uses: actions/checkout@v3
+      - name: get-python-version
+        run: |
+          echo "python_version=$(cat .python-version)" >> $GITHUB_OUTPUT
+      - uses: actions/setup-python@v3
+        with:
+          python-version: ${{ steps.get-python-version.outputs.python_version }}
+      - uses: actions/cache@v3
+        id: cache-restore
+        with:
+          path: |
+            .venv
+          key: ${{ runner.os }}-${{ hashFiles('**/requirements*.txt') }}-${{ steps.get-python-version.outputs.python_version }}
+      - name: Lint
+        run: |
+          . script/bootstrap
+          pytest

--- a/Taskfile.backend.yml
+++ b/Taskfile.backend.yml
@@ -1,5 +1,8 @@
 version: '3'
 
+env:
+  VENV_ACTIVATE: "/{{ .TASKFILE_DIR }}/backend/.venv/bin/activate"
+
 tasks:
   bootstrap:
     internal: true
@@ -9,33 +12,37 @@ tasks:
   lint:
     desc: "Lints /backend using black + pylint."
     deps: [bootstrap]
-    cmds:
-      - black . --check
-      - pylint
+    cmd: source {{ .VENV_ACTIVATE }} && black . --check && pylint ./rotini
     dir: backend
   lintfix:
     desc: "Lints and fixes /backend using black + pylint."
     deps: [bootstrap]
-    cmds:
-      - black .
-      - pylint rotini
+    cmd: source {{ .VENV_ACTIVATE }} && black . && pylint ./rotini
+    dir: backend
+  test:
+    desc: "Run the test suites."
+    deps: [bootstrap]
+    cmd: source {{ .VENV_ACTIVATE }} && pytest .
     dir: backend
   start:
     desc: "Starts the backend application."
     deps: [bootstrap]
-    cmds:
-      - source ../.venv/bin/activate && source ../.env && python -m uvicorn main:app
+    dotenv:
+      - "../.env"
+    cmd: source {{ .VENV_ACTIVATE }} && python -m uvicorn main:app
     dir: backend/rotini
   migrate:
     desc: "Applies migrations. Usage: be:migrate -- <up|down>"
     deps: [bootstrap]
+    dotenv:
+      - "../../.env"
     cmds:
-      - source ../../.venv/bin/activate && source ../../.env && python migrate.py {{.CLI_ARGS}}
+      - source {{ .VENV_ACTIVATE }} && python migrate.py {{.CLI_ARGS}}
     dir: backend/rotini/migrations
   lock-deps:
     desc: "Locks production and development dependencies"
     deps: [bootstrap]
     cmds:
-      - source .venv/bin/activate && . script/requirements-lock
+      - source {{ .VENV_ACTIVATE }} && . script/requirements-lock
     dir: backend
 

--- a/backend/requirements_dev.in
+++ b/backend/requirements_dev.in
@@ -2,3 +2,5 @@
 
 black~=23.7.0
 pylint~=2.17.0
+pytest
+httpx

--- a/backend/requirements_dev.txt
+++ b/backend/requirements_dev.txt
@@ -1,13 +1,41 @@
+anyio==3.7.1
+    # via
+    #   -c requirements.txt
+    #   httpcore
 astroid==2.15.6
     # via pylint
 black==23.7.0
     # via -r requirements_dev.in
+certifi==2023.7.22
+    # via
+    #   httpcore
+    #   httpx
 click==8.1.6
     # via
     #   -c requirements.txt
     #   black
 dill==0.3.7
     # via pylint
+exceptiongroup==1.1.2
+    # via
+    #   -c requirements.txt
+    #   anyio
+    #   pytest
+h11==0.14.0
+    # via
+    #   -c requirements.txt
+    #   httpcore
+httpcore==0.17.3
+    # via httpx
+httpx==0.24.1
+    # via -r requirements_dev.in
+idna==3.4
+    # via
+    #   -c requirements.txt
+    #   anyio
+    #   httpx
+iniconfig==2.0.0
+    # via pytest
 isort==5.12.0
     # via pylint
 lazy-object-proxy==1.9.0
@@ -17,19 +45,32 @@ mccabe==0.7.0
 mypy-extensions==1.0.0
     # via black
 packaging==23.1
-    # via black
+    # via
+    #   black
+    #   pytest
 pathspec==0.11.2
     # via black
 platformdirs==3.10.0
     # via
     #   black
     #   pylint
+pluggy==1.2.0
+    # via pytest
 pylint==2.17.5
     # via -r requirements_dev.in
+pytest==7.4.0
+    # via -r requirements_dev.in
+sniffio==1.3.0
+    # via
+    #   -c requirements.txt
+    #   anyio
+    #   httpcore
+    #   httpx
 tomli==2.0.1
     # via
     #   black
     #   pylint
+    #   pytest
 tomlkit==0.12.1
     # via pylint
 typing-extensions==4.7.1

--- a/backend/tests/test_stub.py
+++ b/backend/tests/test_stub.py
@@ -1,0 +1,2 @@
+def test_stub():
+    pass


### PR DESCRIPTION
Introduces `pytest` and associated `task` command to prepare to write better test coverage. Also tidies up the backend `Taskfile` to reduce cruft, notably:
- Less duplication around `.venv` handling for backend commands that need it;
- Usage of `dotenv` instead of manual sourcing for env files in `start` and `migrate`