### PR TITLE
build(backend): add db-aware testing tooling

### DIFF
--- a/.github/workflows/backend-pipeline.yml
+++ b/.github/workflows/backend-pipeline.yml
@@ -3,6 +3,10 @@ name: Backend Pipeline
 on:
   workflow_call:
 
+env:
+  TASK_VERSION: 3.28.0
+
+
 jobs:
   setup:
     runs-on: ubuntu-latest
@@ -42,6 +46,10 @@ jobs:
       - uses: actions/setup-python@v3
         with:
           python-version: ${{ steps.get-python-version.outputs.python_version }}
+      - name: Setup Task
+        uses: arduino/setup-task@v1
+        with:
+          version: ${{ env.TASK_VERSION }}
       - uses: actions/cache@v3
         id: cache-restore
         with:
@@ -50,8 +58,7 @@ jobs:
           key: ${{ runner.os }}-${{ hashFiles('**/requirements*.txt') }}-${{ steps.get-python-version.outputs.python_version }}
       - name: Lint
         run: |
-          . script/bootstrap
-          black . --check
+          task be:lint
   test:
     runs-on: ubuntu-latest
     name: Test
@@ -67,10 +74,10 @@ jobs:
       - uses: actions/setup-python@v3
         with:
           python-version: ${{ steps.get-python-version.outputs.python_version }}
-      - name: Install Task
+      - name: Setup Task
         uses: arduino/setup-task@v1
         with:
-          version: 3.28.0
+          version: ${{ env.TASK_VERSION }}
       - uses: actions/cache@v3
         id: cache-restore
         with:
@@ -79,5 +86,4 @@ jobs:
           key: ${{ runner.os }}-${{ hashFiles('**/requirements*.txt') }}-${{ steps.get-python-version.outputs.python_version }}
       - name: Test
         run: |
-          . script/bootstrap
           task be:test

--- a/.github/workflows/backend-pipeline.yml
+++ b/.github/workflows/backend-pipeline.yml
@@ -67,13 +67,17 @@ jobs:
       - uses: actions/setup-python@v3
         with:
           python-version: ${{ steps.get-python-version.outputs.python_version }}
+      - name: Install Task
+        uses: arduino/setup-task@v1
+        with:
+          version: 3.28.0
       - uses: actions/cache@v3
         id: cache-restore
         with:
           path: |
             .venv
           key: ${{ runner.os }}-${{ hashFiles('**/requirements*.txt') }}-${{ steps.get-python-version.outputs.python_version }}
-      - name: Lint
+      - name: Test
         run: |
           . script/bootstrap
-          pytest
+          task be:test

--- a/Taskfile.backend.yml
+++ b/Taskfile.backend.yml
@@ -22,7 +22,7 @@ tasks:
   test:
     desc: "Run the test suites."
     deps: [bootstrap]
-    cmd: source {{ .VENV_ACTIVATE }} && pytest .
+    cmd: . script/test
     dir: backend
   start:
     desc: "Starts the backend application."

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,0 +1,5 @@
+[tool.pytest.ini_options]
+pythonpath=[
+    ".",
+    "./rotini",
+]

--- a/backend/rotini/db.py
+++ b/backend/rotini/db.py
@@ -1,6 +1,6 @@
-import os
-
 import psycopg2
+
+import settings
 
 
 def get_connection():
@@ -8,9 +8,9 @@ def get_connection():
     Create a database connection.
     """
     return psycopg2.connect(
-        user=os.environ["DATABASE_USERNAME"],
-        password=os.environ["DATABASE_PASSWORD"],
-        host=os.environ["DATABASE_HOST"],
-        port=os.environ["DATABASE_PORT"],
-        database=os.environ["DATABASE_NAME"],
+        user=settings.DATABASE_USERNAME,
+        password=settings.DATABASE_PASSWORD,
+        host=settings.DATABASE_HOST,
+        port=settings.DATABASE_PORT,
+        database=settings.DATABASE_NAME,
     )

--- a/backend/rotini/migrations/migrate.py
+++ b/backend/rotini/migrations/migrate.py
@@ -38,6 +38,8 @@ import sys
 
 import psycopg2
 
+import settings
+
 VALID_COMMANDS = ["up", "down", "new"]
 
 DIRECTION_UP = 1
@@ -57,11 +59,11 @@ def _get_connection():
     Create a database connection.
     """
     return psycopg2.connect(
-        user=os.environ["DATABASE_USERNAME"],
-        password=os.environ["DATABASE_PASSWORD"],
-        host=os.environ["DATABASE_HOST"],
-        port=os.environ["DATABASE_PORT"],
-        database=os.environ["DATABASE_NAME"],
+        user=settings.DATABASE_USERNAME,
+        password=settings.DATABASE_PASSWORD,
+        host=settings.DATABASE_HOST,
+        port=settings.DATABASE_PORT,
+        database=settings.DATABASE_NAME,
     )
 
 
@@ -90,7 +92,7 @@ def _get_migration_sequence() -> typing.List[MigrationItem]:
     This will detect duplicates and breaks in the sequence
     and raise if the history is not linear and complete.
     """
-    migrations_dir = pathlib.Path(".")
+    migrations_dir = pathlib.Path(__file__).parent
     migrations: typing.Dict[MigrationID, MigrationModuleName] = {}
     dependency_map: typing.Dict[MigrationID, MigrationID] = {}
 
@@ -177,6 +179,7 @@ def migrate(direction: typing.Union[typing.Literal[1], typing.Literal[-1]]):
             print(f"Applying {migrations_to_apply[pos][1]}")
             cursor.execute(sql)
 
+        print(migrations_to_apply)
         next_last_applied = (
             None if direction == DIRECTION_DOWN else migrations_to_apply[-1].id
         )

--- a/backend/rotini/settings.py
+++ b/backend/rotini/settings.py
@@ -1,0 +1,5 @@
+DATABASE_USERNAME = "postgres"
+DATABASE_PASSWORD = "test"
+DATABASE_HOST = "localhost"
+DATABASE_PORT = 5431
+DATABASE_NAME = "postgres"

--- a/backend/script/test
+++ b/backend/script/test
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+TEST_DB_CONTAINER=rotini-test-ephemeral
+
+docker run \
+    --name $TEST_DB_CONTAINER \
+    -e POSTGRES_PASSWORD=test \
+    -p 5431:5432 \
+    -d \
+    postgres:15.4
+
+sleep 2
+
+PYTHONPATH=rotini .venv/bin/python rotini/migrations/migrate.py up
+.venv/bin/pytest .
+
+docker stop $TEST_DB_CONTAINER
+docker remove $TEST_DB_CONTAINER

--- a/backend/tests/test_api_files.py
+++ b/backend/tests/test_api_files.py
@@ -1,0 +1,15 @@
+from fastapi.testclient import TestClient
+import pytest
+
+from rotini.main import app
+
+
+@pytest.fixture()
+def client():
+    return TestClient(app)
+
+
+def test_list_files(client):
+    response = client.get("/files/")
+
+    print(response)


### PR DESCRIPTION
To avoid depending on mocks and to avoid drifting from what the app uses, tests should run on Postgres. This introduces a test harness that uses an ephemeral Postgres container, runs migrations, runs the tests and trashes it afterwards.

The whole thing is wrapped in `task be:test` and is used in CI as well for parity.