### PR TITLE
perf(backend): cache .venv path correctly

### DIFF
--- a/.github/workflows/backend-pipeline.yml
+++ b/.github/workflows/backend-pipeline.yml
@@ -26,7 +26,7 @@ jobs:
         id: cache-restore
         with:
           path: |
-            .venv
+            backend/.venv
           key: ${{ runner.os }}-${{ hashFiles('**/requirements*.txt') }}-${{ steps.get-python-version.outputs.python_version }}
       - name: Install dependencies
         if: steps.cache-restore.outputs.cache-hit != 'true'
@@ -54,7 +54,7 @@ jobs:
         id: cache-restore
         with:
           path: |
-            .venv
+            backend/.venv
           key: ${{ runner.os }}-${{ hashFiles('**/requirements*.txt') }}-${{ steps.get-python-version.outputs.python_version }}
       - name: Lint
         run: |
@@ -82,7 +82,7 @@ jobs:
         id: cache-restore
         with:
           path: |
-            .venv
+            backend/.venv
           key: ${{ runner.os }}-${{ hashFiles('**/requirements*.txt') }}-${{ steps.get-python-version.outputs.python_version }}
       - name: Test
         run: |

--- a/.github/workflows/frontend-pipeline.yml
+++ b/.github/workflows/frontend-pipeline.yml
@@ -23,7 +23,7 @@ jobs:
         id: cache-restore
         with:
           path: |
-            .yarn
+            frontend/.yarn
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}-${{ env.NODE_VERSION }}
       - name: Install dependencies
         if: steps.cache-restore.outputs.cache-hit != 'true'
@@ -45,7 +45,7 @@ jobs:
         id: yarn-cache-restore
         with:
           path: |
-            .yarn
+            frontend/.yarn
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}-${{ env.NODE_VERSION }}
       - name: Lint
         run: |
@@ -68,7 +68,7 @@ jobs:
         id: yarn-cache-restore
         with:
           path: |
-            .yarn
+            frontend/.yarn
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}-${{ env.NODE_VERSION }}
       - name: Test
         run: |
@@ -91,13 +91,12 @@ jobs:
         id: yarn-cache-restore
         with:
           path: |
-            .yarn
+            frontend/.yarn
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}-${{ env.NODE_VERSION }}
       - name: Typecheck
         run: |
           . script/bootstrap
           yarn typecheck
-
   build:
     runs-on: ubuntu-latest
     name: Build App
@@ -115,14 +114,14 @@ jobs:
         id: yarn-cache-restore
         with:
           path: |
-            .yarn
+            frontend/.yarn
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}-${{ env.NODE_VERSION }}
       - name: Parcel cache
         uses: actions/cache@v3
         id: parcel-cache-restore
         with:
           path: |
-            .parcel-cache
+            frontend/.parcel-cache
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}-${{ env.NODE_VERSION }}-parcel
       - run: |
           . script/bootstrap
@@ -148,7 +147,7 @@ jobs:
         id: yarn-cache-restore
         with:
           path: |
-            .yarn
+            frontend/.yarn
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}-${{ env.NODE_VERSION }}
       - run: . script/bootstrap
       - name: Build Artifacts
@@ -193,7 +192,7 @@ jobs:
         id: yarn-cache-restore
         with:
           path: |
-            .yarn
+            frontend/.yarn
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}-${{ env.NODE_VERSION }}
       - run: . script/bootstrap
       - name: Build Artifacts


### PR DESCRIPTION
The `path` input of caching actions was not set properly to account for the `frontend/` and `backend/` namespacing of each app. The confusion might have stemmed from the working directory default that's on `run` blocks but that wouldn't apply to `uses`.

Prefixing cache retrieval paths with the appropriate top-level directory allows the post-action in _Setup_ to cache dependencies correctly, and each of the steps to retrieve it as they should.

:tada: Builds are now superfast.