### PR TITLE
ci: control go-task version at top-level

### DIFF
--- a/.github/workflows/backend-pipeline.yml
+++ b/.github/workflows/backend-pipeline.yml
@@ -2,10 +2,10 @@ name: Backend Pipeline
 
 on:
   workflow_call:
-
-env:
-  TASK_VERSION: 3.28.0
-
+    inputs:
+      task-version:
+        required: true
+        type: string
 
 jobs:
   setup:
@@ -49,7 +49,7 @@ jobs:
       - name: Setup Task
         uses: arduino/setup-task@v1
         with:
-          version: ${{ env.TASK_VERSION }}
+          version: ${{ inputs.task-version }}
       - uses: actions/cache@v3
         id: cache-restore
         with:
@@ -77,7 +77,7 @@ jobs:
       - name: Setup Task
         uses: arduino/setup-task@v1
         with:
-          version: ${{ env.TASK_VERSION }}
+          version: ${{ inputs.task-version }}
       - uses: actions/cache@v3
         id: cache-restore
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,5 +54,7 @@ jobs:
     if: needs.preflight.outputs.be_changed == 'true'
   frontend:
     uses: ./.github/workflows/frontend-pipeline.yml
+    with:
+      task-version: ${{ needs.preflight.outputs.task_version }}
     needs: preflight
     if: needs.preflight.outputs.fe_changed == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
 
 env:
   CI: 1
+  TASK_VERSION: "3.28.0"
 
 jobs:
   preflight:
@@ -16,6 +17,7 @@ jobs:
     outputs:
       be_changed: ${{ steps.change-check.outputs.be_changed }}
       fe_changed: ${{ steps.change-check.outputs.fe_changed }}
+      task_version: ${{ env.TASK_VERSION }}
     steps:
       - uses: actions/checkout@v3
         with:
@@ -46,6 +48,8 @@ jobs:
           fi
   backend:
     uses: ./.github/workflows/backend-pipeline.yml
+    with:
+      task-version: ${{ needs.preflight.outputs.task_version }}
     needs: preflight
     if: needs.preflight.outputs.be_changed == 'true'
   frontend:

--- a/.github/workflows/frontend-pipeline.yml
+++ b/.github/workflows/frontend-pipeline.yml
@@ -2,6 +2,10 @@ name: Frontend Pipeline
 
 on:
   workflow_call:
+    inputs:
+      task-version:
+        required: true
+        type: string
 
 env:
   NODE_VERSION: lts/hydrogen
@@ -40,6 +44,10 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ env.NODE_VERSION }}
+      - name: Setup Task
+        uses: arduino/setup-task@v1
+        with:
+          version: ${{ inputs.task-version }}
       - name: Yarn cache
         uses: actions/cache@v3
         id: yarn-cache-restore
@@ -48,9 +56,7 @@ jobs:
             frontend/.yarn
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}-${{ env.NODE_VERSION }}
       - name: Lint
-        run: |
-          . script/bootstrap
-          yarn lint
+        run: task fe:lint
   test:
     runs-on: ubuntu-latest
     name: Test
@@ -63,6 +69,10 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ env.NODE_VERSION }}
+      - name: Setup Task
+        uses: arduino/setup-task@v1
+        with:
+          version: ${{ inputs.task-version }}
       - name: Yarn cache
         uses: actions/cache@v3
         id: yarn-cache-restore
@@ -71,9 +81,7 @@ jobs:
             frontend/.yarn
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}-${{ env.NODE_VERSION }}
       - name: Test
-        run: |
-          . script/bootstrap
-          yarn test
+        run: task fe:test
   typecheck:
     runs-on: ubuntu-latest
     name: Typecheck
@@ -86,6 +94,10 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ env.NODE_VERSION }}
+      - name: Setup Task
+        uses: arduino/setup-task@v1
+        with:
+          version: ${{ inputs.task-version }}
       - name: Yarn cache
         uses: actions/cache@v3
         id: yarn-cache-restore
@@ -94,9 +106,7 @@ jobs:
             frontend/.yarn
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}-${{ env.NODE_VERSION }}
       - name: Typecheck
-        run: |
-          . script/bootstrap
-          yarn typecheck
+        run: task fe:typecheck
   build:
     runs-on: ubuntu-latest
     name: Build App
@@ -109,6 +119,10 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ env.NODE_VERSION }}
+      - name: Setup Task
+        uses: arduino/setup-task@v1
+        with:
+          version: ${{ inputs.task-version }}
       - name: Yarn cache
         uses: actions/cache@v3
         id: yarn-cache-restore
@@ -123,9 +137,7 @@ jobs:
           path: |
             frontend/.parcel-cache
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}-${{ env.NODE_VERSION }}-parcel
-      - run: |
-          . script/bootstrap
-          yarn build
+      - run: task fe:build
       - name: Build Artifacts
         uses: actions/upload-artifact@v3
         with:

--- a/Taskfile.frontend.yml
+++ b/Taskfile.frontend.yml
@@ -12,6 +12,12 @@ tasks:
     cmds:
       - yarn start
     dir: frontend
+  build:
+    desc: "Build the app."
+    deps: [bootstrap]
+    cmds:
+      - yarn build
+    dir: frontend
   test:
     desc: "Runs the frontend test suite."
     deps: [bootstrap]


### PR DESCRIPTION
`go-task` wraps individual app commands; for parity and conciseness, it can be used in CI. This hoists the version setting for `go-task` up to the top-level CI pipeline and passes it down. All jobs that can now use `go-task` instead of calling yarn / python modules.