### PR TITLE
test(backend): list+details tests

### DIFF
--- a/backend/rotini/api/files.py
+++ b/backend/rotini/api/files.py
@@ -37,6 +37,6 @@ def get_file_details(file_id: str):
     file = files_use_cases.get_file_record_by_id(file_id)
 
     if file is None:
-        return HTTPException(status_code=404)
+        raise HTTPException(status_code=404)
 
     return file

--- a/backend/rotini/use_cases/files.py
+++ b/backend/rotini/use_cases/files.py
@@ -37,7 +37,7 @@ def create_file_record(path: str, size: int) -> FileRecord:
             "INSERT INTO files (path, size) VALUES (%s, %s) RETURNING id", (path, size)
         )
 
-        inserted_id = cursor.fetchone()
+        inserted_id = cursor.fetchone()[0]
 
     filename = pathlib.Path(path).name
 

--- a/backend/script/test
+++ b/backend/script/test
@@ -11,8 +11,8 @@ docker run \
 
 sleep 2
 
-PYTHONPATH=rotini .venv/bin/python rotini/migrations/migrate.py up
-.venv/bin/pytest .
+PYTHONPATH=rotini .venv/bin/python rotini/migrations/migrate.py up || echo "Migrations failed."
+.venv/bin/pytest . -vv -s || echo "Test run failed."
 
 docker stop $TEST_DB_CONTAINER
 docker remove $TEST_DB_CONTAINER

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,16 @@
+from fastapi.testclient import TestClient
+import pytest
+
+from rotini.main import app
+from rotini.db import get_connection
+
+
+@pytest.fixture(name="client")
+def fixture_client():
+    return TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def reset_database():
+    with get_connection() as conn, conn.cursor() as cursor:
+        cursor.execute("DELETE FROM files;")

--- a/backend/tests/test_api_files.py
+++ b/backend/tests/test_api_files.py
@@ -1,15 +1,27 @@
-from fastapi.testclient import TestClient
-import pytest
-
-from rotini.main import app
+from rotini.use_cases import files as files_use_cases
 
 
-@pytest.fixture()
-def client():
-    return TestClient(app)
+def test_list_files_returns_registered_files_and_200(client):
+    file_1 = files_use_cases.create_file_record("/test1.txt", 123)
+    file_2 = files_use_cases.create_file_record("/test2.txt", 456)
 
-
-def test_list_files(client):
     response = client.get("/files/")
 
-    print(response)
+    assert response.status_code == 200
+    assert response.json() == [file_1, file_2]
+
+
+def test_file_details_returns_specified_file_and_200(client):
+    file = files_use_cases.create_file_record("/test1.txt", 123)
+
+    response = client.get(f"/files/{file['id']}/")
+
+    assert response.status_code == 200
+    assert response.json() == file
+
+
+def test_file_details_returns_404_if_does_not_exist(client):
+    non_existent_id = "06f02980-864d-4832-a894-2e9d2543a79a"
+    response = client.get(f"/files/{non_existent_id}/")
+
+    assert response.status_code == 404


### PR DESCRIPTION
Goes over testing for list+details flows and opportunistically fixes two minor issues with the details flow (raising `HTTPException` properly, getting the inserted ID from new rows instead of the tuple returned by `psycopg2`).

This also makes the test script more graceful when failure happens and ensures that cleanup is done on Docker.