### PR TITLE
build: tooling clean-up

### DIFF
--- a/.github/workflows/backend-pipeline.yml
+++ b/.github/workflows/backend-pipeline.yml
@@ -10,13 +10,14 @@ on:
 env:
   ROTINI_CI: 1
 
+defaults:
+  run:
+    working-directory: backend
+
 jobs:
   setup:
     runs-on: ubuntu-latest
     name: Setup
-    defaults:
-      run:
-        working-directory: backend
     steps:
       - uses: actions/checkout@v3
       - name: get-python-version
@@ -38,9 +39,6 @@ jobs:
     runs-on: ubuntu-latest
     name: Lint
     needs: setup
-    defaults:
-      run:
-        working-directory: backend
     steps:
       - uses: actions/checkout@v3
       - name: get-python-version
@@ -66,9 +64,6 @@ jobs:
     runs-on: ubuntu-latest
     name: Test
     needs: setup
-    defaults:
-      run:
-        working-directory: backend
     steps:
       - uses: actions/checkout@v3
       - name: get-python-version

--- a/.github/workflows/frontend-pipeline.yml
+++ b/.github/workflows/frontend-pipeline.yml
@@ -11,13 +11,14 @@ env:
   NODE_VERSION: lts/hydrogen
   CI: 1
 
+defaults:
+  run:
+    working-directory: frontend
+
 jobs:
   setup:
     runs-on: ubuntu-latest
     name: Setup
-    defaults:
-      run:
-        working-directory: frontend
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
@@ -35,9 +36,6 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     name: Lint
-    defaults:
-      run:
-        working-directory: frontend
     needs: setup
     steps:
       - uses: actions/checkout@v3
@@ -60,9 +58,6 @@ jobs:
   test:
     runs-on: ubuntu-latest
     name: Test
-    defaults:
-      run:
-        working-directory: frontend
     needs: setup
     steps:
       - uses: actions/checkout@v3
@@ -85,9 +80,6 @@ jobs:
   typecheck:
     runs-on: ubuntu-latest
     name: Typecheck
-    defaults:
-      run:
-        working-directory: frontend
     needs: setup
     steps:
       - uses: actions/checkout@v3
@@ -110,9 +102,6 @@ jobs:
   build:
     runs-on: ubuntu-latest
     name: Build App
-    defaults:
-      run:
-        working-directory: frontend
     needs: setup
     steps:
       - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -3,5 +3,20 @@ An unnamed cloud storage app
 
 ## Development
 
-Run `. script/bootstrap` to enable `task` commands that make everything else simpler. Then, `task -l` will list out
-available utilities.
+### Tooling
+
+Utility commands are managed by [go-task](https://github.com/go-task/task) and can be called from anywhere. Running `.
+script/bootstrap` installs `go-task` within the project and gets everything ready. From there, `task -l` provides a
+breakdown of available tools.
+
+Note that this is the preferred way to running any tooling-related task within the repository, regardless of
+environment.
+
+### Running locally
+
+The application requires a Postgres database instance to be made available to the backend. This can be done for you via
+`task be:start-db`.
+
+Starting the backend and frontend applications can be done via `task be:start` and `task fe:start`.
+
+See the README files of each of those environments ([backend](./backend/README.md), [frontend](./frontend/README.md)) for specific requirements (i.e. environment dotfiles).

--- a/Taskfile.backend.yml
+++ b/Taskfile.backend.yml
@@ -1,7 +1,10 @@
 version: '3'
 
 env:
-  VENV_ACTIVATE: "/{{ .TASKFILE_DIR }}/backend/.venv/bin/activate"
+  VENV_PATH: "/{{ .TASKFILE_DIR }}/backend/.venv"
+  VENV_BIN: "{{ .VENV_PATH }}/bin"
+  VENV_ACTIVATE: "{{ .VENV_BIN }}/activate"
+  DOTENV: "/{{ .TASKFILE_DIR }}/backend/.env"
 
 tasks:
   bootstrap:
@@ -12,12 +15,16 @@ tasks:
   lint:
     desc: "Lints /backend using black + pylint."
     deps: [bootstrap]
-    cmd: source {{ .VENV_ACTIVATE }} && black . --check && pylint ./rotini
+    cmds:
+      - "{{ .VENV_BIN }}/black . --check"
+      - "{{ .VENV_BIN }}/pylint ./rotini"
     dir: backend
   lintfix:
     desc: "Lints and fixes /backend using black + pylint."
     deps: [bootstrap]
-    cmd: source {{ .VENV_ACTIVATE }} && black . && pylint ./rotini
+    cmds:
+      - "{{ .VENV_BIN }}/black ."
+      - "{{ .VENV_BIN }}/pylint ./rotini"
     dir: backend
   test:
     desc: "Run the test suites."
@@ -28,27 +35,25 @@ tasks:
     desc: "Starts the backend application."
     deps: [bootstrap]
     dotenv:
-      - "../.env"
-    cmd: source {{ .VENV_ACTIVATE }} && python -m uvicorn main:app
+      - "{{ .DOTENV }}"
+    cmd: "{{ .VENV_BIN }}/python -m uvicorn main:app"
     dir: backend/rotini
   start-db:
     desc: "Provisions a local Postgres database."
     dotenv:
-      - ".env"
+      - "{{ .DOTENV }}"
     cmd: . script/provision-db
     dir: backend
   migrate:
     desc: "Applies migrations. Usage: be:migrate -- <up|down>"
     deps: [bootstrap]
     dotenv:
-      - "../../.env"
-    cmds:
-      - source {{ .VENV_ACTIVATE }} && python migrate.py {{.CLI_ARGS}}
+      - "{{ .DOTENV }}"
+    cmd: "{{ .VENV_BIN }}/python migrate.py {{ .CLI_ARGS }}"
     dir: backend/rotini/migrations
   lock-deps:
     desc: "Locks production and development dependencies"
     deps: [bootstrap]
-    cmds:
-      - source {{ .VENV_ACTIVATE }} && . script/requirements-lock
+    cmd: . script/requirements-lock
     dir: backend
 

--- a/Taskfile.frontend.yml
+++ b/Taskfile.frontend.yml
@@ -3,42 +3,35 @@ version: '3'
 tasks:
   bootstrap:
     internal: true
-    cmds:
-      - . script/bootstrap
+    cmd: . script/bootstrap
     dir: frontend
   start:
     desc: "Starts the frontend application."
     deps: [bootstrap]
-    cmds:
-      - yarn start
+    cmd: yarn start
     dir: frontend
   build:
     desc: "Build the app."
     deps: [bootstrap]
-    cmds:
-      - yarn build
+    cmd: yarn build
     dir: frontend
   test:
     desc: "Runs the frontend test suite."
     deps: [bootstrap]
-    cmds:
-      - yarn test
+    cmd: yarn test
     dir: frontend
   lint:
     desc: "Checks lint and formatting."
     deps: [bootstrap]
-    cmds:
-      - yarn lint
+    cmd: yarn lint
     dir: frontend
   lintfix:
     desc: "Fixes lint and formatting."
     deps: [bootstrap]
-    cmds:
-      - yarn lint:fix
+    cmd: yarn lint:fix
     dir: frontend
   typecheck:
     desc: "Validates types."
     deps: [bootstrap]
-    cmds:
-      - yarn typecheck
+    cmd: yarn typecheck
     dir: frontend

--- a/backend/script/requirements-lock
+++ b/backend/script/requirements-lock
@@ -1,3 +1,6 @@
 #!/bin/bash
 
-pip-compile requirements.in --no-header && pip-compile requirements_dev.in --no-header
+PIP_COMPILE=.venv/bin/pip-compile
+
+$PIP_COMPILE requirements.in --no-header \
+    && $PIP_COMPILE requirements_dev.in --no-header


### PR DESCRIPTION
Ties in some loose ends around tooling:

- Removes extra syntax around `Taskfile` commands, notable using `cmd` instead of `cmds` in single command calls;
- Replaces usages of `source` in tasks and scripts to point directly at venv executables;
- Defines working directory defaults at a higher level in CI to avoid repetition.