### PR TITLE
ci: sentinel step for env pipeline success

### DIFF
--- a/.github/workflows/backend-pipeline.yml
+++ b/.github/workflows/backend-pipeline.yml
@@ -6,6 +6,9 @@ on:
       task-version:
         required: true
         type: string
+    outputs:
+      pipeline-success:
+        value: ${{ jobs.notify-success.outputs.pipeline_success }}
 
 env:
   ROTINI_CI: 1
@@ -85,3 +88,13 @@ jobs:
       - name: Test
         run: |
           task be:test
+  notify-success:
+    runs-on: ubuntu-latest
+    name: Notify success
+    needs: [lint, test]
+    steps:
+      - id: set-output
+        working-directory: /
+        run: echo "pipeline_success=true" >> "$GITHUB_OUTPUT"
+    outputs:
+      pipeline_success: ${{ steps.set-output.outputs.pipeline_success }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
           fi
           if [ -n "$(git diff --name-only origin/main origin/${GITHUB_HEAD_REF} -- ./.github)" ]
           then
-            echo "fe_changed=false" >> "$GITHUB_OUTPUT"
+            echo "fe_changed=true" >> "$GITHUB_OUTPUT"
             echo "be_changed=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
@@ -69,4 +69,35 @@ jobs:
         || needs.preflight.outputs.fe_changed == 'false'
       )
     steps:
-      - run: true
+      - run: |
+          if [ "${{ needs.preflight.outputs.fe_changed }}" == "false" ]
+          then
+            exit 0
+          fi
+          if [ "${{ needs.frontend.outputs.pipeline-success }}" == "true" ]
+          then
+            exit 0
+          fi
+          exit 1
+  backend-ok:
+    name: Backend Pipeline Success
+    runs-on: ubuntu-latest
+    needs: [backend, preflight]
+    if: |
+      always()
+      && (
+        needs.backend.outputs.pipeline-success == 'true'
+        || needs.preflight.outputs.be_changed == 'false'
+      )
+    steps:
+      - run: |
+          if [ "${{ needs.preflight.outputs.be_changed }}" == "false" ]
+          then
+            exit 0
+          fi
+          if [ "${{ needs.backend.outputs.pipeline-success }}" == "true" ]
+          then
+            exit 0
+          fi
+          exit 1
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
           fi
           if [ -n "$(git diff --name-only origin/main origin/${GITHUB_HEAD_REF} -- ./.github)" ]
           then
-            echo "fe_changed=true" >> "$GITHUB_OUTPUT"
+            echo "fe_changed=false" >> "$GITHUB_OUTPUT"
             echo "be_changed=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
@@ -58,3 +58,15 @@ jobs:
       task-version: ${{ needs.preflight.outputs.task_version }}
     needs: preflight
     if: needs.preflight.outputs.fe_changed == 'true'
+  frontend-ok:
+    name: Frontend Pipeline Success
+    runs-on: ubuntu-latest
+    needs: [frontend, preflight]
+    if: |
+      always()
+      && (
+        needs.frontend.outputs.pipeline-success == 'true'
+        || needs.preflight.outputs.fe_changed == 'false'
+      )
+    steps:
+      - run: true

--- a/.github/workflows/frontend-pipeline.yml
+++ b/.github/workflows/frontend-pipeline.yml
@@ -8,7 +8,7 @@ on:
         type: string
     outputs:
       pipeline-success:
-        value: ${{ jobs.notify-success.outputs.pipeline-success }}
+        value: ${{ jobs.notify-success.outputs.pipeline_success }}
 
 env:
   NODE_VERSION: lts/hydrogen

--- a/.github/workflows/frontend-pipeline.yml
+++ b/.github/workflows/frontend-pipeline.yml
@@ -183,7 +183,7 @@ jobs:
   notify-success:
     runs-on: ubuntu-latest
     name: Notify success
-    needs: [lint, test, typecheck]
+    needs: [lint, test, typecheck, build]
     steps:
       - id: set-output
         working-directory: /

--- a/.github/workflows/frontend-pipeline.yml
+++ b/.github/workflows/frontend-pipeline.yml
@@ -6,6 +6,9 @@ on:
       task-version:
         required: true
         type: string
+    outputs:
+      pipeline-success:
+        value: ${{ jobs.notify-success.outputs.pipeline-success }}
 
 env:
   NODE_VERSION: lts/hydrogen
@@ -177,6 +180,16 @@ jobs:
               repo: context.repo.repo,
               body: `:eyes: Branch deployed at ${process.env.DRAFT_URL}`
             })
+  notify-success:
+    runs-on: ubuntu-latest
+    name: Notify success
+    needs: [lint, test, typecheck]
+    steps:
+      - id: set-output
+        working-directory: /
+        run: echo "pipeline_success=true" >> "$GITHUB_OUTPUT"
+    outputs:
+      pipeline_success: ${{ steps.set-output.outputs.pipeline_success }}
   fe-deploy:
     runs-on: ubuntu-latest
     name: Deploy


### PR DESCRIPTION
Add a pipeline-success step to both frontend and backend to have an overall status.

If a pipeline isn't triggered (due to no change) or has run successfully, the pipeline is successful. This provides two targets for status checks that are always success/failures (rather than skipped steps).