### PR TITLE
build(backend): run as a container

### DIFF
--- a/.github/workflows/backend-pipeline.yml
+++ b/.github/workflows/backend-pipeline.yml
@@ -88,6 +88,18 @@ jobs:
       - name: Test
         run: |
           task be:test
+  docker-build:
+    runs-on: ubuntu-latest
+    name: Build Development Docker Image
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Task
+        uses: arduino/setup-task@v1
+        with:
+          version: ${{ inputs.task-version }}
+      - name: Build
+        run: |
+          task be:docker-build
   notify-success:
     runs-on: ubuntu-latest
     name: Notify success

--- a/README.md
+++ b/README.md
@@ -19,4 +19,25 @@ The application requires a Postgres database instance to be made available to th
 
 Starting the backend and frontend applications can be done via `task be:start` and `task fe:start`.
 
-See the README files of each of those environments ([backend](./backend/README.md), [frontend](./frontend/README.md)) for specific requirements (i.e. environment dotfiles).
+#### Starting the backend application
+
+The backend application is available as a container, which you can run as
+
+```sh
+task be:start
+```
+
+If you opt to run your database in an adjacent container, you can either run containers in such a manner than they share
+a network or define the database's host via `docker.host.internal`:
+
+```sh
+task be:start -- --add-host docker.host.internal:host-gateway
+```
+
+More generally, extra options can be passed to the `docker run` call that runs the application this way:
+
+```sh
+task be:start -- <options>
+```
+
+See the README files of each of those environments ([backend](./backend/README.md), [frontend](./frontend/README.md)) for specific requirements..

--- a/Taskfile.backend.yml
+++ b/Taskfile.backend.yml
@@ -33,10 +33,8 @@ tasks:
     dir: backend
   start:
     desc: "Starts the backend application."
-    deps: [bootstrap]
-    dotenv:
-      - "{{ .DOTENV }}"
-    cmd: "{{ .VENV_BIN }}/python -m uvicorn main:app"
+    deps: [docker-build]
+    cmd: docker run -d -p 8000:8000 --name rotini_app {{ .CLI_ARGS }} rotini:dev
     dir: backend/rotini
   start-db:
     desc: "Provisions a local Postgres database."
@@ -58,4 +56,7 @@ tasks:
     deps: [bootstrap]
     cmd: . script/requirements-lock
     dir: backend
-
+  docker-build:
+    desc: "Builds a docker image from /backend"
+    cmd: docker build --build-arg PYTHON_VERSION=$(cat .python-version) -t rotini:dev .
+    dir: backend

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,48 @@
+FROM ubuntu:jammy
+
+ARG PYTHON_VERSION
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV TARGET_PYTHON_VERSION=$PYTHON_VERSION
+
+RUN apt update && apt upgrade -y
+
+RUN apt-get install -y \
+        build-essential \
+        checkinstall \
+        libreadline-dev \
+        libncursesw5-dev \
+        libssl-dev \
+        libsqlite3-dev \
+        tk-dev \
+        libgdbm-dev \
+        libc6-dev \
+        libbz2-dev \
+        libpq-dev \
+        wget
+
+WORKDIR /app
+
+COPY .python-version ./
+
+WORKDIR /tmp
+
+RUN wget https://www.python.org/ftp/python/$TARGET_PYTHON_VERSION/Python-$TARGET_PYTHON_VERSION.tgz
+RUN tar xzf ./Python-$TARGET_PYTHON_VERSION.tgz
+
+WORKDIR /tmp/Python-$TARGET_PYTHON_VERSION
+
+RUN ./configure && make install
+
+WORKDIR /app
+
+COPY ./requirements.txt ./requirements.txt
+
+RUN python3 -m pip install -U pip==23.0.0 pip-tools==7.1.0
+RUN python3 -m pip install -r ./requirements.txt
+
+COPY ./rotini ./rotini
+
+WORKDIR ./rotini
+
+CMD python3 -m uvicorn main:app --host 0.0.0.0


### PR DESCRIPTION
This sets up the backend to be run as a container via Docker.

The Dockerfile included is a starting point and will need revising before being ready for publishing, but it is a functional stepping stone during development to simplify day-to-day work.

The `task be:start` command was upgraded to leverage the Docker container as well.

CI also now builds Docker images. At this point, no publishing is done, but this verifies that the image can be built.