### PR TITLE
build: use python:x-slim base

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,38 +1,14 @@
-FROM ubuntu:jammy
-
 ARG PYTHON_VERSION
 
+FROM python:$PYTHON_VERSION-slim
+
 ENV DEBIAN_FRONTEND=noninteractive
-ENV TARGET_PYTHON_VERSION=$PYTHON_VERSION
 
 RUN apt update && apt upgrade -y
 
 RUN apt-get install -y \
-        build-essential \
-        checkinstall \
-        libreadline-dev \
-        libncursesw5-dev \
-        libssl-dev \
-        libsqlite3-dev \
-        tk-dev \
-        libgdbm-dev \
-        libc6-dev \
-        libbz2-dev \
-        libpq-dev \
-        wget
-
-WORKDIR /app
-
-COPY .python-version ./
-
-WORKDIR /tmp
-
-RUN wget https://www.python.org/ftp/python/$TARGET_PYTHON_VERSION/Python-$TARGET_PYTHON_VERSION.tgz
-RUN tar xzf ./Python-$TARGET_PYTHON_VERSION.tgz
-
-WORKDIR /tmp/Python-$TARGET_PYTHON_VERSION
-
-RUN ./configure && make install
+        gcc \
+        libpq-dev
 
 WORKDIR /app
 


### PR DESCRIPTION
Trims down the Dockerfile by using the `python:{version}-slim` base image.

Initially, `ubuntu:jammy` was used to get a general image and Python was built from source on it. This made builds rather long. Using the specific `python` image has the right Python version baked in, thus quicker builds, and `slim` keeps the image size as low as it can.

Alpine variants were also considered, but ultimately yielded larger images.