### PR TITLE
feat(frontend): file downloads

### DIFF
--- a/frontend/src/components/FileDetails.tsx
+++ b/frontend/src/components/FileDetails.tsx
@@ -8,7 +8,11 @@ import MuiDownloadIcon from "@mui/icons-material/Download"
 import MuiIconButton from "@mui/material/IconButton"
 
 import { useLocationContext } from "../contexts/LocationContext"
-import { useFileDetails, useFileMutations } from "../queries/files"
+import {
+	useFileDetails,
+	useFileMutations,
+	useFileFetches,
+} from "../queries/files"
 
 interface FileDetailsProps {
 	itemId: string
@@ -18,12 +22,9 @@ function FileDetails({ itemId }: FileDetailsProps) {
 	const { isLoading, data } = useFileDetails(itemId)
 	const { deleteFile } = useFileMutations()
 	const { navigate } = useLocationContext()
+	const { downloadFile } = useFileFetches()
 
 	if (isLoading || !data) return null
-
-	const handleDownloadClick = () => {
-		console.log("download click")
-	}
 
 	const currentFileDetails = data
 
@@ -45,7 +46,9 @@ function FileDetails({ itemId }: FileDetailsProps) {
 				<>
 					<MuiIconButton
 						aria-label="download item"
-						onClick={() => handleDownloadClick()}
+						onClick={async () => {
+							await downloadFile(itemId, currentFileDetails.filename)
+						}}
 					>
 						<MuiDownloadIcon />
 					</MuiIconButton>

--- a/frontend/src/components/FileList.tsx
+++ b/frontend/src/components/FileList.tsx
@@ -14,7 +14,11 @@ import MuiTypography from "@mui/material/Typography"
 import { byteSizeToUnits } from "../utils"
 import { useLocationContext } from "../contexts/LocationContext"
 import { useAsyncTaskContext } from "../contexts/AsyncTaskContext"
-import { type FileData, useFileMutations, downloadFile } from "../queries/files"
+import {
+	type FileData,
+	useFileMutations,
+	useFileFetches,
+} from "../queries/files"
 
 interface FileListProps {
 	data: Array<FileData>
@@ -81,6 +85,8 @@ function FileList({ data }: FileListProps) {
 	const { tasks } = useAsyncTaskContext()
 	const { navigate } = useLocationContext()
 	const { deleteFile } = useFileMutations()
+	const { downloadFile } = useFileFetches()
+
 	const onClickHandler = (uid: string) => {
 		navigate(`/item/${uid}/`)
 	}

--- a/frontend/src/components/FileList.tsx
+++ b/frontend/src/components/FileList.tsx
@@ -14,7 +14,7 @@ import MuiTypography from "@mui/material/Typography"
 import { byteSizeToUnits } from "../utils"
 import { useLocationContext } from "../contexts/LocationContext"
 import { useAsyncTaskContext } from "../contexts/AsyncTaskContext"
-import { type FileData, useFileMutations } from "../queries/files"
+import { type FileData, useFileMutations, downloadFile } from "../queries/files"
 
 interface FileListProps {
 	data: Array<FileData>
@@ -84,9 +84,6 @@ function FileList({ data }: FileListProps) {
 	const onClickHandler = (uid: string) => {
 		navigate(`/item/${uid}/`)
 	}
-	const onDownloadHandler = () => {
-		console.log("download")
-	}
 
 	const dataWithPlaceholders = [...tasks, ...data]
 
@@ -99,7 +96,9 @@ function FileList({ data }: FileListProps) {
 				onClickHandler={() =>
 					onClickHandler("id" in itemData ? itemData.id : "")
 				}
-				onDownloadHandler={onDownloadHandler}
+				onDownloadHandler={async () => {
+					"id" in itemData ? downloadFile(itemData.id, itemData.filename) : null
+				}}
 				onDeleteHandler={() =>
 					"id" in itemData ? deleteFile(itemData.id) : null
 				}

--- a/frontend/src/queries/files.ts
+++ b/frontend/src/queries/files.ts
@@ -55,6 +55,23 @@ function useFileMutations(): {
 }
 
 /*
+ * Downloads a file given its ID.
+ *
+ * This function returns nothing and is intended to trigger a download
+ * action in the browser directly.
+ */
+async function downloadFile(fileId: string, fileName: string) {
+	const r = await axiosWithDefaults.get(`/files/${fileId}/content/`)
+	const a = document.createElement("a")
+	const b = r.data
+	a.href = URL.createObjectURL(
+		new Blob([b], { type: "application/octet-stream" }),
+	)
+	a.download = fileName
+	a.click()
+}
+
+/*
  * Uploads a file.
  */
 async function uploadFile(file: File) {
@@ -69,7 +86,13 @@ async function uploadFile(file: File) {
 	return response.data
 }
 
-export { useOwnFileList, useFileDetails, useFileMutations, uploadFile }
+export {
+	useOwnFileList,
+	useFileDetails,
+	useFileMutations,
+	uploadFile,
+	downloadFile,
+}
 
 // Types
 export { FileData }

--- a/frontend/src/queries/files.ts
+++ b/frontend/src/queries/files.ts
@@ -54,21 +54,21 @@ function useFileMutations(): {
 	return { deleteFile }
 }
 
-/*
- * Downloads a file given its ID.
- *
- * This function returns nothing and is intended to trigger a download
- * action in the browser directly.
- */
-async function downloadFile(fileId: string, fileName: string) {
-	const r = await axiosWithDefaults.get(`/files/${fileId}/content/`)
-	const a = document.createElement("a")
-	const b = r.data
-	a.href = URL.createObjectURL(
-		new Blob([b], { type: "application/octet-stream" }),
-	)
-	a.download = fileName
-	a.click()
+function useFileFetches(): {
+	downloadFile: (fileId: string, fileName: string) => Promise<void>
+} {
+	const downloadFile = async (fileId: string, fileName: string) => {
+		const r = await axiosWithDefaults.get(`/files/${fileId}/content/`)
+		const a = document.createElement("a")
+		const b = r.data
+		a.href = URL.createObjectURL(
+			new Blob([b], { type: "application/octet-stream" }),
+		)
+		a.download = fileName
+		a.click()
+	}
+
+	return { downloadFile }
 }
 
 /*
@@ -90,8 +90,8 @@ export {
 	useOwnFileList,
 	useFileDetails,
 	useFileMutations,
+	useFileFetches,
 	uploadFile,
-	downloadFile,
 }
 
 // Types

--- a/frontend/src/queries/files.ts
+++ b/frontend/src/queries/files.ts
@@ -54,18 +54,30 @@ function useFileMutations(): {
 	return { deleteFile }
 }
 
+/*
+ * Hook providing callable async functions implementing one-off
+ * fetches on the files API.
+ *
+ * Returns:
+ *  downloadFile: Triggers a file download.
+ *
+ */
 function useFileFetches(): {
 	downloadFile: (fileId: string, fileName: string) => Promise<void>
 } {
+	/*
+	 * Downloading the file is done by fetching the binary blob from the
+	 * API and creating a "virtual" anchor element that we programmatically
+	 * click. This is a hack to trigger a file download from a non-file URL.
+	 */
 	const downloadFile = async (fileId: string, fileName: string) => {
-		const r = await axiosWithDefaults.get(`/files/${fileId}/content/`)
-		const a = document.createElement("a")
-		const b = r.data
-		a.href = URL.createObjectURL(
-			new Blob([b], { type: "application/octet-stream" }),
+		const response = await axiosWithDefaults.get(`/files/${fileId}/content/`)
+		const virtualAnchor = document.createElement("a")
+		virtualAnchor.href = URL.createObjectURL(
+			new Blob([response.data], { type: "application/octet-stream" }),
 		)
-		a.download = fileName
-		a.click()
+		virtualAnchor.download = fileName
+		virtualAnchor.click()
 	}
 
 	return { downloadFile }

--- a/frontend/tests/FileList.test.tsx
+++ b/frontend/tests/FileList.test.tsx
@@ -97,5 +97,34 @@ describe("FileList", () => {
 
 			expect(deleteRequest.url).toMatch(expectedUrlPattern)
 		})
+
+		test("Clicking the download button trigger a file download", async () => {
+			// FIXME: Validating file downloads is ... tricky. The current interaction with dynamically created DOM
+			// elements is not visible by jest.
+			const expectedUrlPattern = new RegExp(
+				`/files/${mockItems[0].id}/content/$`,
+			)
+
+			const axiosMock = getAxiosMockAdapter()
+
+			axiosMock.onGet(expectedUrlPattern).reply(200, mockItems[0])
+
+			const user = userEvent.setup()
+
+			const { getByLabelText, debug } = render(
+				<FileList data={[mockItems[0]]} />,
+			)
+			const downloadButton = getByLabelText("download item")
+
+			await user.click(downloadButton)
+
+			const getRequests = axiosMock.history.get
+
+			expect(getRequests.length).toEqual(1)
+
+			const getRequest = getRequests[0]
+
+			expect(getRequest.url).toMatch(expectedUrlPattern)
+		})
 	})
 })

--- a/frontend/tests/testSetup.ts
+++ b/frontend/tests/testSetup.ts
@@ -2,3 +2,6 @@
 globalThis.URL.createObjectURL = jest
 	.fn()
 	.mockImplementation(() => "http://localhost/downloadUrl")
+
+// Clicking DOM objects is not implemented in jest-jsdom.
+HTMLAnchorElement.prototype.click = jest.fn()

--- a/frontend/tests/testSetup.ts
+++ b/frontend/tests/testSetup.ts
@@ -1,0 +1,4 @@
+// URL.createObjectURL does not exist in jest-jsdom.
+globalThis.URL.createObjectURL = jest
+	.fn()
+	.mockImplementation(() => "http://localhost/downloadUrl")


### PR DESCRIPTION
This introduces functionality for the download buttons in the main filelist and the file details panel.

:warning: **Testing flaw**

Testing around the virtual anchor used to trigger downloads proved tricky, `FIXME` comments were left to tag the two cases that are lackluster.

Because the action of fetching from the API is covered and QA covered the interaction, this is considered "accepted risk".