### PR TITLE
perf(backend): avoid double-reading uploaded file streams

### DIFF
--- a/backend/rotini/api/files.py
+++ b/backend/rotini/api/files.py
@@ -31,12 +31,11 @@ async def upload_file(file: UploadFile) -> files_use_cases.FileRecord:
         The file was uploaded and registered successfully.
     """
 
-    size = None
+    content = await file.read()
+    size = len(content)
     dest_path = pathlib.Path(settings.STORAGE_ROOT, file.filename)
 
     with open(dest_path, "wb") as f:
-        content = await file.read()
-        size = len(content)
         f.write(content)
 
     created_record = files_use_cases.create_file_record(str(dest_path), size)

--- a/backend/rotini/api/files.py
+++ b/backend/rotini/api/files.py
@@ -22,13 +22,12 @@ def list_files():
 
 @router.post("/")
 async def upload_file(file: UploadFile):
-    content = await file.read()
-    size = len(content)
-    await file.seek(0)
-
+    size = None
     dest_path = pathlib.Path(settings.STORAGE_ROOT, file.filename)
+
     with open(dest_path, "wb") as f:
         content = await file.read()
+        size = len(content)
         f.write(content)
 
     created_record = files_use_cases.create_file_record(str(dest_path), size)

--- a/backend/rotini/api/files.py
+++ b/backend/rotini/api/files.py
@@ -20,8 +20,17 @@ def list_files():
     return files_use_cases.get_all_file_records()
 
 
-@router.post("/")
-async def upload_file(file: UploadFile):
+@router.post("/", status_code=201)
+async def upload_file(file: UploadFile) -> files_use_cases.FileRecord:
+    """
+    Receives files uploaded by the user, saving them to disk and
+    recording their existence in the database.
+
+    201 { <FileRecord> }
+
+        The file was uploaded and registered successfully.
+    """
+
     size = None
     dest_path = pathlib.Path(settings.STORAGE_ROOT, file.filename)
 


### PR DESCRIPTION
Uploading a file previously involved a double-read of the data; once to determine the size and another to write to disk. This consolidates the two.

Opportunistically adds missing documentation to the upload flow, including return types, documented behaviour and status code.