### PR TITLE
perf: avoid redundant bootstrap runs on commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ yarn-error.log*
 lerna-debug.log*
 .pnpm-debug.log*
 
+.task
 bin
 
 .venv

--- a/Taskfile.backend.yml
+++ b/Taskfile.backend.yml
@@ -1,16 +1,21 @@
 version: '3'
 
 env:
-  VENV_PATH: "/{{ .TASKFILE_DIR }}/backend/.venv"
+  BASE_PATH: "/{{ .TASKFILE_DIR }}/backend"
+  VENV_PATH: "{{ .BASE_PATH }}/.venv"
   VENV_BIN: "{{ .VENV_PATH }}/bin"
   VENV_ACTIVATE: "{{ .VENV_BIN }}/activate"
-  DOTENV: "/{{ .TASKFILE_DIR }}/backend/.env"
+  DOTENV: "{{ .BASE_PATH }}/.env"
 
 tasks:
   bootstrap:
     internal: true
     cmds:
       - . script/bootstrap
+    sources:
+      - "{{ .BASE_PATH }}/*.in"
+    generates:
+      - "{{ .VENV_PATH }}/*"
     dir: backend
   lint:
     desc: "Lints /backend using black + pylint."

--- a/Taskfile.frontend.yml
+++ b/Taskfile.frontend.yml
@@ -1,9 +1,16 @@
 version: '3'
 
+env:
+  BASE_PATH: "/{{ .TASKFILE_DIR }}/frontend"
+
 tasks:
   bootstrap:
     internal: true
     cmd: . script/bootstrap
+    sources:
+      - "{{ .BASE_PATH }}/yarn.lock"
+    generates:
+      - "{{ .BASE_PATH }}/.yarn/*"
     dir: frontend
   start:
     desc: "Starts the frontend application."


### PR DESCRIPTION
Running most commands depends on the environment's `bootstrap` step that makes sure that dependencies are set up. Previously, the step ran every time it's invoked, even if it ends up being a no-op (mostly).

Even in no-op scenarios, work is being done to validate that dependencies are met, which isn't useful at all.

This leverages `sources` and `generates` to keep track of env artifact checksums and skip bootstrap if already up-to-date.