### PR TITLE
fix: trigger ci run if taskfile changes + split basepath env variable…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
             echo "be_changed=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          if [ -n "$(git diff --name-only origin/main origin/${GITHUB_HEAD_REF} -- ./.github)" ]
+          if [ -n "$(git diff --name-only origin/main origin/${GITHUB_HEAD_REF} -- ./.github ./Taskfile*.yml)" ]
           then
             echo "fe_changed=true" >> "$GITHUB_OUTPUT"
             echo "be_changed=true" >> "$GITHUB_OUTPUT"

--- a/Taskfile.backend.yml
+++ b/Taskfile.backend.yml
@@ -1,8 +1,8 @@
 version: '3'
 
 env:
-  BASE_PATH: "/{{ .TASKFILE_DIR }}/backend"
-  VENV_PATH: "{{ .BASE_PATH }}/.venv"
+  BE_BASE_PATH: "/{{ .TASKFILE_DIR }}/backend"
+  VENV_PATH: "{{ .BE_BASE_PATH }}/.venv"
   VENV_BIN: "{{ .VENV_PATH }}/bin"
   VENV_ACTIVATE: "{{ .VENV_BIN }}/activate"
   DOTENV: "{{ .BASE_PATH }}/.env"
@@ -13,7 +13,7 @@ tasks:
     cmds:
       - . script/bootstrap
     sources:
-      - "{{ .BASE_PATH }}/*.in"
+      - "{{ .BE_BASE_PATH }}/*.in"
     generates:
       - "{{ .VENV_PATH }}/*"
     dir: backend

--- a/Taskfile.frontend.yml
+++ b/Taskfile.frontend.yml
@@ -1,16 +1,16 @@
 version: '3'
 
 env:
-  BASE_PATH: "/{{ .TASKFILE_DIR }}/frontend"
+  FE_BASE_PATH: "/{{ .TASKFILE_DIR }}/frontend"
 
 tasks:
   bootstrap:
     internal: true
     cmd: . script/bootstrap
     sources:
-      - "{{ .BASE_PATH }}/yarn.lock"
+      - "{{ .FE_BASE_PATH }}/yarn.lock"
     generates:
-      - "{{ .BASE_PATH }}/.yarn/*"
+      - "{{ .FE_BASE_PATH }}/.yarn/*"
     dir: frontend
   start:
     desc: "Starts the frontend application."


### PR DESCRIPTION
`BASE_PATH`, defined in the individual envs the Taskfile sets became a shared property, causing it to leak from `frontend` to `backend` since the former is defined first in the root Taskfile.

This addresses the issue (differentiation of the two `BASE_PATH` variables) by prefixing either base paths with a `BE_` and `FE_` prefix. It also makes sure it cannot reoccur silently like it did by triggering CI runs if any changes exist in the Taskfiles (which is what caught this in the `main` branch).