### PR TITLE
build(backend): ensure that migrate settings set host properly

### DIFF
--- a/Taskfile.backend.yml
+++ b/Taskfile.backend.yml
@@ -5,7 +5,7 @@ env:
   VENV_PATH: "{{ .BE_BASE_PATH }}/.venv"
   VENV_BIN: "{{ .VENV_PATH }}/bin"
   VENV_ACTIVATE: "{{ .VENV_BIN }}/activate"
-  DOTENV: "{{ .BASE_PATH }}/.env"
+  DOTENV: "{{ .BE_BASE_PATH }}/.env"
 
 tasks:
   bootstrap:
@@ -52,6 +52,7 @@ tasks:
     deps: [bootstrap]
     env:
       PYTHONPATH: '..'
+      ROTINI_MIGRATE: 1
     dotenv:
       - "{{ .DOTENV }}"
     cmd: "{{ .VENV_BIN }}/python migrate.py {{ .CLI_ARGS }}"

--- a/backend/rotini/envs/migrate.py
+++ b/backend/rotini/envs/migrate.py
@@ -1,0 +1,3 @@
+from envs.local import *
+
+DATABASE_HOST = "localhost"

--- a/backend/rotini/settings.py
+++ b/backend/rotini/settings.py
@@ -4,6 +4,7 @@ import typing
 
 IS_CI = os.getenv("ROTINI_CI")
 IS_TEST = os.getenv("ROTINI_TEST")
+IS_MIGRATE = os.getenv("ROTINI_MIGRATE")
 
 
 class Settings:
@@ -43,8 +44,12 @@ if IS_CI is not None:
 elif IS_TEST is not None:
     import envs.test as test_config
 
-    settings = extract_settings("ci", test_config)
+    settings = extract_settings("test", test_config)
+elif IS_MIGRATE is not None:
+    import envs.migrate as migrate_config
+
+    settings = extract_settings("migrate", migrate_config)
 else:
     import envs.local as local_config
 
-    settings = extract_settings("ci", local_config)
+    settings = extract_settings("local", local_config)

--- a/backend/script/provision-db
+++ b/backend/script/provision-db
@@ -22,4 +22,4 @@ until [ -n "$(docker exec $CONTAINER_NAME pg_isready | grep accepting)" ]; do
     sleep 0.1;
 done;
 
-PYTHONPATH=rotini .venv/bin/python rotini/migrations/migrate.py up
+PYTHONPATH=rotini ROTINI_MIGRATE=1 .venv/bin/python rotini/migrations/migrate.py up


### PR DESCRIPTION
Previously, the migration script used the `envs.local` settings, which might have the host set up wrong due to migrations running outside the container, but the application accessing the database from inside.

Ideally, migrations should be run through the container to avoid having to have a different configuration, but for now, separate configuration will ease the pain of having to switch settings to set up the database and to run the application locally.