### PR TITLE
feat(backend): manage user sessions using tokens

### DIFF
--- a/backend/requirements.in
+++ b/backend/requirements.in
@@ -5,4 +5,5 @@ psycopg2
 typing_extensions
 pydantic ~= 2.0
 
+pyjwt~=2.8
 argon2-cffi~=23.1

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -27,9 +27,13 @@ psycopg2==2.9.7
 pycparser==2.21
     # via cffi
 pydantic==2.1.1
-    # via fastapi
+    # via
+    #   -r requirements.in
+    #   fastapi
 pydantic-core==2.4.0
     # via pydantic
+pyjwt==2.8.0
+    # via -r requirements.in
 python-dotenv==1.0.0
     # via uvicorn
 python-multipart==0.0.6

--- a/backend/rotini/auth/base.py
+++ b/backend/rotini/auth/base.py
@@ -18,5 +18,14 @@ class CreateUserRequestData(pydantic.BaseModel):
     password: str
 
 
+class IdentityTokenData(pydantic.BaseModel):
+    """Contents of an identity token"""
+
+    exp: int
+    user_id: int
+    username: str
+    token_id: str
+
+
 class UsernameAlreadyExists(Exception):
     """Signals a unique constraint violation on username values"""

--- a/backend/rotini/auth/decorators.py
+++ b/backend/rotini/auth/decorators.py
@@ -1,0 +1,25 @@
+import functools
+
+import fastapi
+
+
+def requires_logged_in(func):
+    """
+    Returns a 401 if the request received does not specify a logged
+    in user in its state.
+
+    The state is added through auth.middleware functionality.
+
+    Note that this requires the endpoint to be aware of the fastapi.Request
+    keyword argument passed to it.
+    """
+
+    @functools.wraps(func)
+    async def wrapper(*, request: fastapi.Request, **kwargs):
+        if not hasattr(request.state, "user"):
+            raise fastapi.HTTPException(status_code=401)
+
+        response = await func(**kwargs)
+        return response
+
+    return wrapper

--- a/backend/rotini/auth/decorators.py
+++ b/backend/rotini/auth/decorators.py
@@ -15,11 +15,11 @@ def requires_logged_in(func):
     """
 
     @functools.wraps(func)
-    async def wrapper(*, request: fastapi.Request, **kwargs):
+    async def wrapper(request: fastapi.Request, *args, **kwargs):
         if not hasattr(request.state, "user"):
             raise fastapi.HTTPException(status_code=401)
 
-        response = await func(**kwargs)
+        response = await func(request, *args, **kwargs)
         return response
 
     return wrapper

--- a/backend/rotini/auth/middleware.py
+++ b/backend/rotini/auth/middleware.py
@@ -1,0 +1,29 @@
+from fastapi import Request
+
+from main import app
+
+import auth.use_cases as auth_use_cases
+
+
+@app.middleware("http")
+async def authentication_middleware(request: Request, call_next):
+    """
+    Decodes Authorization headers if present on the request and sets
+    identifying fields in the request state.
+
+    This information is then leveraged by individual routes to determine
+    authorization.
+    """
+    auth_header = request.headers.get("authorization")
+
+    if auth_header is not None:
+        _, token = auth_header.split(" ")
+        decoded_token = auth_use_cases.decode_token(token)
+        print(decoded_token)
+        request.state.user = {
+            "username": decoded_token["username"],
+            "user_id": decoded_token["user_id"],
+        }
+
+    response = await call_next(request)
+    return response

--- a/backend/rotini/auth/middleware.py
+++ b/backend/rotini/auth/middleware.py
@@ -1,8 +1,19 @@
+"""
+Authentication & authorization middleware logic.
+
+This module is imported dynamically from `settings` to set up
+middlewares with the `FastAPI` singleton.
+"""
+import logging
+
+import jwt.exceptions
 from fastapi import Request
 
 from main import app
 
 import auth.use_cases as auth_use_cases
+
+logger = logging.getLogger(__name__)
 
 
 @app.middleware("http")
@@ -15,11 +26,17 @@ async def authentication_middleware(request: Request, call_next):
     authorization.
     """
     auth_header = request.headers.get("authorization")
+    decoded_token = None
 
     if auth_header is not None:
         _, token = auth_header.split(" ")
-        decoded_token = auth_use_cases.decode_token(token)
-        print(decoded_token)
+        try:
+            decoded_token = auth_use_cases.decode_token(token)
+        except jwt.exceptions.ExpiredSignatureError as exc:
+            logger.exception(exc)
+
+    if decoded_token is not None:
+        logger.info(decoded_token)
         request.state.user = {
             "username": decoded_token["username"],
             "user_id": decoded_token["user_id"],

--- a/backend/rotini/auth/routes.py
+++ b/backend/rotini/auth/routes.py
@@ -1,4 +1,5 @@
 from fastapi import APIRouter, HTTPException
+from fastapi.responses import JSONResponse
 
 from exceptions import DoesNotExist
 
@@ -59,4 +60,9 @@ async def log_in(payload: auth_base.LoginRequestData):
     if not auth_use_cases.validate_password_for_user(user["id"], payload.password):
         raise HTTPException(status_code=401)
 
-    return user
+    token = auth_use_cases.generate_token_for_user(user)
+
+    return JSONResponse(
+        content={"username": user["username"]},
+        headers={"Authorization": f"Bearer {token}"},
+    )

--- a/backend/rotini/main.py
+++ b/backend/rotini/main.py
@@ -1,10 +1,13 @@
 """
 Rotini: a self-hosted cloud storage & productivity app.
 """
+import importlib
+
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 import auth.routes as auth_routes
+
 import files.routes as files_routes
 
 app = FastAPI()
@@ -20,9 +23,13 @@ app.add_middleware(
 )
 
 routers = [files_routes.router, auth_routes.router]
+middlewares = ["auth.middleware"]
 
 for router in routers:
     app.include_router(router)
+
+for middleware in middlewares:
+    importlib.import_module(middleware)
 
 
 @app.get("/", status_code=204)

--- a/backend/rotini/settings.py
+++ b/backend/rotini/settings.py
@@ -14,12 +14,17 @@ class Settings:
     """
 
     ENV: str
+
     DATABASE_USERNAME: str
     DATABASE_PASSWORD: str
     DATABASE_HOST: str
     DATABASE_PORT: int
     DATABASE_NAME: str
+
     STORAGE_ROOT: typing.Optional[str] = "."
+
+    JWT_SECRET_KEY: str = "placeholder"
+    JWT_LIFETIME: int = 60
 
     def __init__(self, *_, **kwargs):
         for key, value in kwargs.items():

--- a/backend/rotini/settings.py
+++ b/backend/rotini/settings.py
@@ -24,7 +24,7 @@ class Settings:
     STORAGE_ROOT: typing.Optional[str] = "."
 
     JWT_SECRET_KEY: str = "placeholder"
-    JWT_LIFETIME: int = 60
+    JWT_LIFETIME: int = 900  # 15 minutes.
 
     def __init__(self, *_, **kwargs):
         for key, value in kwargs.items():


### PR DESCRIPTION
This is a follow-up to #31 and generates JWT tokens when the user hits the `sessions` API. The token is returned via the response's Authorization header and can be reused to access endpoints that are adorned with the `requires_logged_in` decorator.

The `requires_logged_in` decorator checks that a valid JWT is attached to the request, a first step in being able to validate the ownership of files.

One step further into #29.