### PR TITLE
feat(backend): file permissions and ownership

### DIFF
--- a/backend/.pylintrc
+++ b/backend/.pylintrc
@@ -434,7 +434,8 @@ disable=raw-checker-failed,
         missing-module-docstring,
         too-many-locals,
         line-too-long,
-        too-few-public-methods
+        too-few-public-methods,
+        fixme
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/backend/.pylintrc
+++ b/backend/.pylintrc
@@ -433,7 +433,8 @@ disable=raw-checker-failed,
         missing-function-docstring,
         missing-module-docstring,
         too-many-locals,
-        line-too-long
+        line-too-long,
+        too-few-public-methods
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/backend/requirements_dev.in
+++ b/backend/requirements_dev.in
@@ -1,5 +1,6 @@
 -c requirements.txt
 
+anyio~=3.7.0
 black~=23.7.0
 pylint~=2.17.0
 pytest

--- a/backend/requirements_dev.txt
+++ b/backend/requirements_dev.txt
@@ -1,6 +1,7 @@
 anyio==3.7.1
     # via
     #   -c requirements.txt
+    #   -r requirements_dev.in
     #   httpcore
 astroid==2.15.6
     # via pylint

--- a/backend/rotini/files/base.py
+++ b/backend/rotini/files/base.py
@@ -1,0 +1,13 @@
+import typing_extensions as typing
+
+
+class FileRecord(typing.TypedDict):
+    """
+    Database record associated with a file tracked
+    by the system.
+    """
+
+    id: str
+    size: int
+    path: str
+    filename: str

--- a/backend/rotini/main.py
+++ b/backend/rotini/main.py
@@ -1,11 +1,11 @@
 """
 Rotini: a self-hosted cloud storage & productivity app.
 """
-import importlib
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
+import auth.middleware as auth_middleware
 import auth.routes as auth_routes
 
 import files.routes as files_routes
@@ -21,15 +21,12 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+app.add_middleware(auth_middleware.AuthenticationMiddleware)
 
 routers = [files_routes.router, auth_routes.router]
-middlewares = ["auth.middleware"]
 
 for router in routers:
     app.include_router(router)
-
-for middleware in middlewares:
-    importlib.import_module(middleware)
 
 
 @app.get("/", status_code=204)

--- a/backend/rotini/migrations/migration_2_permissions.py
+++ b/backend/rotini/migrations/migration_2_permissions.py
@@ -18,8 +18,8 @@ UP_SQL = """CREATE TABLE
     value bigint NOT NULL,
     created_at timestamp DEFAULT now(),
     updated_at timestamp DEFAULT now(),
-    CONSTRAINT file_fk FOREIGN KEY(file_id) REFERENCES files(id),
-    CONSTRAINT user_fk FOREIGN KEY(user_id) REFERENCES users(id),
+    CONSTRAINT file_fk FOREIGN KEY(file_id) REFERENCES files(id) ON DELETE CASCADE,
+    CONSTRAINT user_fk FOREIGN KEY(user_id) REFERENCES users(id) ON DELETE CASCADE,
     CONSTRAINT unique_permission_per_file_per_user UNIQUE(file_id, user_id)
 );
 """

--- a/backend/rotini/migrations/migration_2_permissions.py
+++ b/backend/rotini/migrations/migration_2_permissions.py
@@ -1,0 +1,27 @@
+"""
+Generated: 2023-08-27T11:56:17.800102
+
+Message: Sets up permission-tracking on files
+"""
+UID = "3c755dd8-e02d-4a29-b4ee-2afa4d9b30d6"
+
+PARENT = "141faa0b-6868-4d07-a24b-b45f98d2809d"
+
+MESSAGE = "Sets up permission-tracking on files"
+
+UP_SQL = """CREATE TABLE
+    permissions_files
+(
+    id bigserial PRIMARY KEY,
+    file_id uuid NOT NULL,
+    user_id bigint NOT NULL,
+    value bigint NOT NULL,
+    created_at timestamp DEFAULT now(),
+    updated_at timestamp DEFAULT now(),
+    CONSTRAINT file_fk FOREIGN KEY(file_id) REFERENCES files(id),
+    CONSTRAINT user_fk FOREIGN KEY(user_id) REFERENCES users(id),
+    CONSTRAINT unique_permission_per_file_per_user UNIQUE(file_id, user_id)
+);
+"""
+
+DOWN_SQL = """DROP TABLE permissions_files;"""

--- a/backend/rotini/permissions/base.py
+++ b/backend/rotini/permissions/base.py
@@ -1,0 +1,23 @@
+import enum
+
+import typing_extensions as typing
+
+
+class Permissions(enum.Enum):
+    """
+    Enumeration of individual permission bits.
+
+    Complex permissions are composed by combining these
+    bits.
+    """
+
+    CAN_VIEW = 1 << 0
+    CAN_DELETE = 1 << 1
+
+
+class FilePermission(typing.TypedDict):
+    """Representation of a permission applicable to a file+user pair"""
+
+    file: str
+    user: int
+    value: typing.List[Permissions]

--- a/backend/rotini/permissions/files.py
+++ b/backend/rotini/permissions/files.py
@@ -1,0 +1,26 @@
+import typing_extensions as typing
+
+from permissions.base import Permissions, FilePermission
+from db import get_connection
+
+
+def set_file_permission(
+    file_id: str, user_id: int, permissions: typing.List[Permissions]
+) -> FilePermission:
+    """
+    Given a file+user pair, creates a permission record with the
+    provided permission list.
+    """
+    permission_value = sum(permission.value for permission in permissions)
+
+    with get_connection() as connection, connection.cursor() as cursor:
+        cursor.execute(
+            "INSERT INTO permissions_files (user_id, file_id, value) VALUES (%s, %s, %s) RETURNING id;",
+            (user_id, file_id, permission_value),
+        )
+        inserted_row = cursor.fetchone()
+
+    if inserted_row is None:
+        raise RuntimeError("uh")
+
+    return FilePermission(file=file_id, user=user_id, value=permissions)

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,24 +1,26 @@
+"""
+Global fixtures
+
+
+"""
 from fastapi.testclient import TestClient
+import httpx
 import pytest
-import unittest.mock
 
-from rotini.main import app
-from rotini.db import get_connection
-
+from main import app
+from db import get_connection
 from settings import settings
 
 
-@pytest.fixture(name="client")
-def fixture_client():
-    return TestClient(app)
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture(autouse=False)
 def reset_database():
-    """
-    Empties all user tables between tests.
-    """
-    tables = ["files", "users"]
+    """Empties all user tables between tests."""
+    tables = ["files", "users", "permissions_files"]
 
     with get_connection() as conn, conn.cursor() as cursor:
         for table in tables:
@@ -26,7 +28,7 @@ def reset_database():
 
 
 @pytest.fixture(autouse=True)
-def set_storage_path(tmp_path, monkeypatch):
+async def set_storage_path(tmp_path, monkeypatch):
     """
     Ensures that files stored by tests are stored
     in temporary directories.
@@ -38,17 +40,56 @@ def set_storage_path(tmp_path, monkeypatch):
     monkeypatch.setattr(settings, "STORAGE_ROOT", str(files_dir))
 
 
+@pytest.fixture(name="test_user_credentials")
+def fixture_test_user_creds():
+    """
+    Test user credentials.
+    """
+    return {"username": "testuser", "password": "testpassword"}
+
+
+@pytest.fixture(name="test_user", autouse=True)
+async def fixture_test_user(client_create_user, test_user_credentials):
+    """
+    Sets up a test user using the `test_user_credentials` data.
+    """
+    yield await client_create_user(test_user_credentials)
+
+
+@pytest.fixture(name="no_auth_client")
+async def fixture_no_auth_client():
+    """HTTP client without any authentication"""
+    async with httpx.AsyncClient(app=app, base_url="http://test") as client:
+        yield client
+
+
+@pytest.fixture(name="jwt_client")
+async def fixture_jwt_client(client_log_in, test_user_credentials):
+    """HTTP client with test user authentication via JWT"""
+    response = await client_log_in(test_user_credentials)
+    auth_header = response.headers["authorization"]
+
+    async with httpx.AsyncClient(
+        app=app, base_url="http://test", headers={"Authorization": auth_header}
+    ) as client:
+        yield client
+
+
 @pytest.fixture(name="client_log_in")
-def fixture_client_log_in(client):
-    def _client_log_in(credentials):
-        return client.post("/auth/sessions/", json=credentials)
+def fixture_client_log_in(no_auth_client):
+    """Logs in as the provided user"""
+
+    async def _client_log_in(credentials):
+        return await no_auth_client.post("/auth/sessions/", json=credentials)
 
     return _client_log_in
 
 
 @pytest.fixture(name="client_create_user")
-def fixture_client_create_user(client):
-    def _client_create_user(credentials):
-        return client.post("/auth/users/", json=credentials)
+def fixture_client_create_user(no_auth_client):
+    """Creates a new user given credentials"""
+
+    async def _client_create_user(credentials):
+        return await no_auth_client.post("/auth/users/", json=credentials)
 
     return _client_create_user

--- a/backend/tests/test_files_routes.py
+++ b/backend/tests/test_files_routes.py
@@ -1,12 +1,16 @@
 import pathlib
 
+import pytest
 
-def test_list_files_returns_registered_files_and_200(client, tmp_path):
+pytestmark = pytest.mark.anyio
+
+
+async def test_list_files_returns_registered_files_and_200(jwt_client, tmp_path):
     mock_file_1 = tmp_path / "test1.txt"
     mock_file_1.write_text("testtest")
 
     with open(str(mock_file_1), "rb") as mock_file_stream:
-        response = client.post("/files/", files={"file": mock_file_stream})
+        response = await jwt_client.post("/files/", files={"file": mock_file_stream})
 
     mock_file_1_data = response.json()
 
@@ -14,104 +18,104 @@ def test_list_files_returns_registered_files_and_200(client, tmp_path):
     mock_file_2.write_text("testtest")
 
     with open(str(mock_file_2), "rb") as mock_file_stream:
-        response = client.post("/files/", files={"file": mock_file_stream})
+        response = await jwt_client.post("/files/", files={"file": mock_file_stream})
 
     mock_file_2_data = response.json()
 
-    response = client.get("/files/")
+    response = await jwt_client.get("/files/")
 
     assert response.status_code == 200
     assert response.json() == [mock_file_1_data, mock_file_2_data]
 
 
-def test_file_details_returns_specified_file_and_200(client, tmp_path):
+async def test_file_details_returns_specified_file_and_200(jwt_client, tmp_path):
     mock_file = tmp_path / "test.txt"
     mock_file.write_text("testtest")
 
     with open(str(mock_file), "rb") as mock_file_stream:
-        response = client.post("/files/", files={"file": mock_file_stream})
+        response = await jwt_client.post("/files/", files={"file": mock_file_stream})
 
     response_data = response.json()
     created_file_id = response_data["id"]
 
-    response = client.get(f"/files/{created_file_id}/")
+    response = await jwt_client.get(f"/files/{created_file_id}/")
 
     assert response.status_code == 200
     assert response.json() == response_data
 
 
-def test_file_details_returns_404_if_does_not_exist(client):
+async def test_file_details_returns_404_if_does_not_exist(jwt_client):
     non_existent_id = "06f02980-864d-4832-a894-2e9d2543a79a"
-    response = client.get(f"/files/{non_existent_id}/")
+    response = await jwt_client.get(f"/files/{non_existent_id}/")
 
     assert response.status_code == 404
 
 
-def test_file_deletion_returns_404_if_does_not_exist(client):
+async def test_file_deletion_returns_404_if_does_not_exist(jwt_client):
     non_existent_id = "06f02980-864d-4832-a894-2e9d2543a79a"
-    response = client.delete(f"/files/{non_existent_id}/")
+    response = await jwt_client.delete(f"/files/{non_existent_id}/")
 
     assert response.status_code == 404
 
 
-def test_file_deletion_deletes_record_and_file(client, tmp_path):
+async def test_file_deletion_deletes_record_and_file(jwt_client, tmp_path):
     mock_file = tmp_path / "test.txt"
     mock_file.write_text("testtest")
 
     with open(str(mock_file), "rb") as mock_file_stream:
-        response = client.post("/files/", files={"file": mock_file_stream})
+        response = await jwt_client.post("/files/", files={"file": mock_file_stream})
 
     response_data = response.json()
     file_id = response_data["id"]
     file_path = response_data["path"]
 
     assert pathlib.Path(file_path).exists()
-    response = client.get(f"/files/{file_id}/")
+    response = await jwt_client.get(f"/files/{file_id}/")
 
     assert response.status_code == 200
 
-    client.delete(f"/files/{file_id}/")
+    await jwt_client.delete(f"/files/{file_id}/")
     assert not pathlib.Path(file_path).exists()
 
-    response = client.get(f"/files/{file_id}/")
+    response = await jwt_client.get(f"/files/{file_id}/")
 
     assert response.status_code == 404
 
 
-def test_file_deletion_200_and_return_deleted_resource(client, tmp_path):
+async def test_file_deletion_200_and_return_deleted_resource(jwt_client, tmp_path):
     mock_file = tmp_path / "test.txt"
     mock_file.write_text("testtest")
 
     with open(str(mock_file), "rb") as mock_file_stream:
-        response = client.post("/files/", files={"file": mock_file_stream})
+        response = await jwt_client.post("/files/", files={"file": mock_file_stream})
 
     response_data = response.json()
     file_id = response_data["id"]
 
-    response = client.delete(f"/files/{file_id}/")
+    response = await jwt_client.delete(f"/files/{file_id}/")
 
     assert response.status_code == 200
     assert response.json() == response_data
 
 
-def test_file_downloads_200_and_return_file(client, tmp_path):
+async def test_file_downloads_200_and_return_file(jwt_client, tmp_path):
     mock_file = tmp_path / "test.txt"
     mock_file.write_text("testtest")
 
     with open(str(mock_file), "rb") as mock_file_stream:
-        response = client.post("/files/", files={"file": mock_file_stream})
+        response = await jwt_client.post("/files/", files={"file": mock_file_stream})
 
     response_data = response.json()
     file_id = response_data["id"]
 
-    response = client.get(f"/files/{file_id}/content/")
+    response = await jwt_client.get(f"/files/{file_id}/content/")
 
     assert response.status_code == 200
     assert response.text == mock_file.read_text()
 
 
-def test_file_downloads_404_if_does_not_exist(client):
+async def test_file_downloads_404_if_does_not_exist(jwt_client):
     non_existent_id = "06f02980-864d-4832-a894-2e9d2543a79a"
-    response = client.get(f"/files/{non_existent_id}/content/")
+    response = await jwt_client.get(f"/files/{non_existent_id}/content/")
 
     assert response.status_code == 404


### PR DESCRIPTION
This adds a draft of the file permission functionality described in #30 and applies it to file uploads / list routes.

See #29.

# API changes
- Listing files is now scoped to the files owned by the current user (user needs to be logged in);
- Uploading files assigns ownership of the file to the logged in user.

:warning: Before the API development goes further, a registration / login flow should exist so the FE can forward authorization headers properly.