### PR TITLE
build(deps): refactor dependency metadata to live in pyproject.toml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ bin
 
 .venv
 **/*.pyc
+*.egg-info*
 
 */.pnp.*
 */.yarn/*

--- a/Taskfile.backend.yml
+++ b/Taskfile.backend.yml
@@ -14,7 +14,7 @@ tasks:
     cmds:
       - . script/bootstrap
     sources:
-      - "{{ .BE_BASE_PATH }}/*.in"
+      - "{{ .BE_BASE_PATH }}/pyproject.toml"
     generates:
       - "{{ .VENV_PATH }}/*"
     dir: backend

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,3 +1,30 @@
+[project]
+name = "rotini"
+version = "0.0.0"
+requires-python = ">= 3.10"
+dependencies = [
+   "fastapi",
+   "uvicorn[standard]",
+   "python-multipart",
+   "typing_extensions",
+   "pydantic",
+   "pyjwt",
+   "argon2-cffi",
+   "psycopg2",
+]
+
+[project.optional-dependencies]
+dev = [
+    "anyio",
+    "black",
+    "pylint",
+    "pytest",
+    "httpx",
+]
+
+[tool.setuptools]
+packages = ["rotini"]
+
 [tool.pytest.ini_options]
 pythonpath=[
     ".",

--- a/backend/requirements.in
+++ b/backend/requirements.in
@@ -1,9 +1,0 @@
-fastapi~=0.101
-uvicorn[standard]
-python-multipart
-psycopg2
-typing_extensions
-pydantic ~= 2.0
-
-pyjwt~=2.8
-argon2-cffi~=23.1

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -5,7 +5,7 @@ anyio==3.7.1
     #   starlette
     #   watchfiles
 argon2-cffi==23.1.0
-    # via -r requirements.in
+    # via rotini (pyproject.toml)
 argon2-cffi-bindings==21.2.0
     # via argon2-cffi
 cffi==1.15.1
@@ -15,7 +15,7 @@ click==8.1.6
 exceptiongroup==1.1.2
     # via anyio
 fastapi==0.101.0
-    # via -r requirements.in
+    # via rotini (pyproject.toml)
 h11==0.14.0
     # via uvicorn
 httptools==0.6.0
@@ -23,21 +23,21 @@ httptools==0.6.0
 idna==3.4
     # via anyio
 psycopg2==2.9.7
-    # via -r requirements.in
+    # via rotini (pyproject.toml)
 pycparser==2.21
     # via cffi
 pydantic==2.1.1
     # via
-    #   -r requirements.in
     #   fastapi
+    #   rotini (pyproject.toml)
 pydantic-core==2.4.0
     # via pydantic
 pyjwt==2.8.0
-    # via -r requirements.in
+    # via rotini (pyproject.toml)
 python-dotenv==1.0.0
     # via uvicorn
 python-multipart==0.0.6
-    # via -r requirements.in
+    # via rotini (pyproject.toml)
 pyyaml==6.0.1
     # via uvicorn
 sniffio==1.3.0
@@ -46,13 +46,13 @@ starlette==0.27.0
     # via fastapi
 typing-extensions==4.7.1
     # via
-    #   -r requirements.in
     #   fastapi
     #   pydantic
     #   pydantic-core
+    #   rotini (pyproject.toml)
     #   uvicorn
 uvicorn[standard]==0.23.2
-    # via -r requirements.in
+    # via rotini (pyproject.toml)
 uvloop==0.17.0
     # via uvicorn
 watchfiles==0.19.0

--- a/backend/requirements_dev.in
+++ b/backend/requirements_dev.in
@@ -1,7 +1,0 @@
--c requirements.txt
-
-anyio~=3.7.0
-black~=23.7.0
-pylint~=2.17.0
-pytest
-httpx

--- a/backend/requirements_dev.txt
+++ b/backend/requirements_dev.txt
@@ -1,20 +1,39 @@
+annotated-types==0.5.0
+    # via
+    #   -c requirements.txt
+    #   pydantic
 anyio==3.7.1
     # via
     #   -c requirements.txt
-    #   -r requirements_dev.in
     #   httpcore
+    #   rotini (pyproject.toml)
+    #   starlette
+    #   watchfiles
+argon2-cffi==23.1.0
+    # via
+    #   -c requirements.txt
+    #   rotini (pyproject.toml)
+argon2-cffi-bindings==21.2.0
+    # via
+    #   -c requirements.txt
+    #   argon2-cffi
 astroid==2.15.6
     # via pylint
 black==23.7.0
-    # via -r requirements_dev.in
+    # via rotini (pyproject.toml)
 certifi==2023.7.22
     # via
     #   httpcore
     #   httpx
+cffi==1.15.1
+    # via
+    #   -c requirements.txt
+    #   argon2-cffi-bindings
 click==8.1.6
     # via
     #   -c requirements.txt
     #   black
+    #   uvicorn
 dill==0.3.7
     # via pylint
 exceptiongroup==1.1.2
@@ -22,14 +41,23 @@ exceptiongroup==1.1.2
     #   -c requirements.txt
     #   anyio
     #   pytest
+fastapi==0.101.0
+    # via
+    #   -c requirements.txt
+    #   rotini (pyproject.toml)
 h11==0.14.0
     # via
     #   -c requirements.txt
     #   httpcore
+    #   uvicorn
 httpcore==0.17.3
     # via httpx
+httptools==0.6.0
+    # via
+    #   -c requirements.txt
+    #   uvicorn
 httpx==0.24.1
-    # via -r requirements_dev.in
+    # via rotini (pyproject.toml)
 idna==3.4
     # via
     #   -c requirements.txt
@@ -57,16 +85,53 @@ platformdirs==3.10.0
     #   pylint
 pluggy==1.2.0
     # via pytest
+psycopg2==2.9.7
+    # via
+    #   -c requirements.txt
+    #   rotini (pyproject.toml)
+pycparser==2.21
+    # via
+    #   -c requirements.txt
+    #   cffi
+pydantic==2.1.1
+    # via
+    #   -c requirements.txt
+    #   fastapi
+    #   rotini (pyproject.toml)
+pydantic-core==2.4.0
+    # via
+    #   -c requirements.txt
+    #   pydantic
+pyjwt==2.8.0
+    # via
+    #   -c requirements.txt
+    #   rotini (pyproject.toml)
 pylint==2.17.5
-    # via -r requirements_dev.in
+    # via rotini (pyproject.toml)
 pytest==7.4.0
-    # via -r requirements_dev.in
+    # via rotini (pyproject.toml)
+python-dotenv==1.0.0
+    # via
+    #   -c requirements.txt
+    #   uvicorn
+python-multipart==0.0.6
+    # via
+    #   -c requirements.txt
+    #   rotini (pyproject.toml)
+pyyaml==6.0.1
+    # via
+    #   -c requirements.txt
+    #   uvicorn
 sniffio==1.3.0
     # via
     #   -c requirements.txt
     #   anyio
     #   httpcore
     #   httpx
+starlette==0.27.0
+    # via
+    #   -c requirements.txt
+    #   fastapi
 tomli==2.0.1
     # via
     #   black
@@ -78,5 +143,26 @@ typing-extensions==4.7.1
     # via
     #   -c requirements.txt
     #   astroid
+    #   fastapi
+    #   pydantic
+    #   pydantic-core
+    #   rotini (pyproject.toml)
+    #   uvicorn
+uvicorn[standard]==0.23.2
+    # via
+    #   -c requirements.txt
+    #   rotini (pyproject.toml)
+uvloop==0.17.0
+    # via
+    #   -c requirements.txt
+    #   uvicorn
+watchfiles==0.19.0
+    # via
+    #   -c requirements.txt
+    #   uvicorn
+websockets==11.0.3
+    # via
+    #   -c requirements.txt
+    #   uvicorn
 wrapt==1.15.0
     # via astroid

--- a/backend/script/bootstrap
+++ b/backend/script/bootstrap
@@ -4,6 +4,6 @@ python -m venv .venv
 
 . .venv/bin/activate
 
-pip install -U pip==23.0.0 pip-tools==7.1.0
+pip install -U pip~=23.3.0 pip-tools~=7.3.0
 
-pip-sync requirements.txt requirements_dev.txt
+pip-sync requirements_dev.txt

--- a/backend/script/requirements-lock
+++ b/backend/script/requirements-lock
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-PIP_COMPILE=.venv/bin/pip-compile
+PYTHON=.venv/bin/python
 
-$PIP_COMPILE requirements.in --no-header \
-    && $PIP_COMPILE requirements_dev.in --no-header
+$PYTHON -m piptools compile -o requirements.txt pyproject.toml --no-header \
+    && $PYTHON -m piptools compile -o requirements_dev.txt --no-header --extra dev --constraint requirements.txt pyproject.toml 

--- a/backend/script/test
+++ b/backend/script/test
@@ -37,8 +37,10 @@ docker run \
 
 until [ -n "$(docker exec $TEST_DB_CONTAINER pg_isready | grep accepting)" ]; do
     echo "Waiting for DB to come alive..."
-    sleep $HEALTHCHECK_SLEEP;
+    sleep $HEALTHCHECK_SLEEP
 done;
+
+sleep $HEALTHCHECK_SLEEP
 
 ROTINI_TEST=1 PYTHONPATH=rotini $VENV_PYTHON rotini/migrations/migrate.py up || fail "Migrations failed."
 ROTINI_TEST=1 $VENV_PYTEST . -vv -s || fail "Test run failed."


### PR DESCRIPTION
# Description

This is a better take on #39. Project metadata gets centralized to `pyproject.toml` (incl. dependencies), which allows us to remove the `.in` files entirely. The lockfiles are now generated from the dependencies that are listed in there and are ensured to be compatible with each other.

`pip-tools` is preserved and its version range is updated (ditto for `pip`).

An adjacent change was also made to the backend test script, which would sometimes fail in CI but not locally. This seems to be a timing issue with bringing up the test database - even waiting for `pg_ready` to be conclusive isn't a guarantee, but an added delay _after_ the last success seems to let it settle.