### PR TITLE
ci(backend): stop building dev images in CI

### DIFF
--- a/.github/workflows/backend-pipeline.yml
+++ b/.github/workflows/backend-pipeline.yml
@@ -88,18 +88,6 @@ jobs:
       - name: Test
         run: |
           task be:test
-  docker-build:
-    runs-on: ubuntu-latest
-    name: Build Development Docker Image
-    steps:
-      - uses: actions/checkout@v4
-      - name: Setup Task
-        uses: arduino/setup-task@v1
-        with:
-          version: ${{ inputs.task-version }}
-      - name: Build
-        run: |
-          task be:docker-build
   notify-success:
     runs-on: ubuntu-latest
     name: Notify success


### PR DESCRIPTION
This discontinues building development Docker images in CI since there won't be uploads to a registry any time soon.