### PR TITLE
build: reduce taskfile backend complexity

### DIFF
--- a/Taskfile.backend.yml
+++ b/Taskfile.backend.yml
@@ -46,8 +46,10 @@ tasks:
   start:
     desc: "Starts the backend application."
     deps: [docker-build]
-    cmd: docker run -d -p 8000:8000 --name {{ .APP_CONTAINER_NAME }} {{ .CLI_ARGS }} --add-host docker.host.internal:host-gateway --env-file ../../backend.env rotini:dev
-    dir: backend/rotini
+    env:
+      APP_CONTAINER_NAME: "{{ .APP_CONTAINER_NAME }}"
+    cmd: . script/start.sh
+    dir: backend
   stop:
     desc: "Stops the backend application."
     cmd: docker rm -f {{ .APP_CONTAINER_NAME }}

--- a/Taskfile.backend.yml
+++ b/Taskfile.backend.yml
@@ -45,7 +45,7 @@ tasks:
       - ../backend-test.env
   start:
     desc: "Starts the backend application."
-    deps: [docker-build]
+    deps: [build]
     env:
       APP_CONTAINER_NAME: "{{ .APP_CONTAINER_NAME }}"
     cmd: . script/start.sh
@@ -62,23 +62,13 @@ tasks:
       - "{{ .DOTENV }}"
     cmd: . script/provision-db
     dir: backend
-  migrate:
-    desc: "Applies migrations. Usage: be:migrate -- <up|down>"
-    deps: [bootstrap]
-    env:
-      PYTHONPATH: '..'
-      ROTINI_MIGRATE: 1
-    dotenv:
-      - "{{ .DOTENV }}"
-    cmd: "{{ .VENV_BIN }}/python migrate.py {{ .CLI_ARGS }}"
-    dir: backend/rotini/migrations
   lock-deps:
     desc: "Locks production and development dependencies"
     deps: [bootstrap]
     cmd: . script/requirements-lock
     dir: backend
-  docker-build:
+  build:
     desc: "Builds a docker image from /backend"
-    cmd: docker build --build-arg PYTHON_VERSION=$(cat .python-version) -t rotini:dev .
+    cmd: . script/build.sh
     dir: backend
 

--- a/Taskfile.backend.yml
+++ b/Taskfile.backend.yml
@@ -34,28 +34,23 @@ tasks:
     cmd: . script/test
     dotenv:
       - ../backend-test.env
-  start:
+  lock-deps:
+    desc: "Locks production and development dependencies"
+    deps: [bootstrap]
+    cmd: . script/requirements-lock
+  docker:start:
     desc: "Starts the backend application."
     deps: [build]
     cmd: . script/start.sh
     dotenv:
       - ../backend.env
-  stop:
+  docker:stop:
     desc: "Stops the backend application."
     cmd: docker rm -f {{ .APP_CONTAINER_NAME }} {{ .DB_CONTAINER_NAME }}
-  logs:
+  docker:logs:
     desc: "Shortcut to Docker container logs"
     cmd: docker logs {{ .APP_CONTAINER_NAME }} -f
-  start-db:
-    desc: "Provisions a local Postgres database."
-    dotenv:
-      - ../backend.env
-    cmd: . script/provision-db
-  lock-deps:
-    desc: "Locks production and development dependencies"
-    deps: [bootstrap]
-    cmd: . script/requirements-lock
-  build:
+  docker:build:
     desc: "Builds a docker image from /backend"
     cmd: . script/build.sh
 

--- a/Taskfile.backend.yml
+++ b/Taskfile.backend.yml
@@ -19,21 +19,19 @@ tasks:
       - "{{ .VENV_PATH }}/*"
     dir: backend
   lint:
-    desc: "Lints /backend using black + pylint."
+    desc: "Checks /backend for linting and formatting problems."
     deps: [bootstrap]
-    cmds:
-      - "{{ .VENV_BIN }}/black . --check"
-      - "{{ .VENV_BIN }}/pylint ./rotini"
+    cmd: . script/format.sh
     dir: backend
     dotenv:
       - ../backend-test.env
   lintfix:
-    desc: "Lints and fixes /backend using black + pylint."
+    desc: "Resolves linting and formatting problems in /backend."
     deps: [bootstrap]
-    cmds:
-      - "{{ .VENV_BIN }}/black ."
-      - "{{ .VENV_BIN }}/pylint ./rotini"
+    cmd: . script/format.sh
     dir: backend
+    env:
+      FIX: 1
     dotenv:
       - ../backend-test.env
   test:

--- a/Taskfile.backend.yml
+++ b/Taskfile.backend.yml
@@ -1,35 +1,29 @@
 version: '3'
 
 env:
-  BE_BASE_PATH: "/{{ .TASKFILE_DIR }}/backend"
-  VENV_PATH: "{{ .BE_BASE_PATH }}/.venv"
+  VENV_PATH: "{{ .TASKFILE_DIR }}/.venv"
   VENV_BIN: "{{ .VENV_PATH }}/bin"
-  VENV_ACTIVATE: "{{ .VENV_BIN }}/activate"
-  DOTENV: "{{ .BE_BASE_PATH }}/.env"
   APP_CONTAINER_NAME: "rotini_app"
+  DB_CONTAINER_NAME: "rotini_db"
 
 tasks:
   bootstrap:
     internal: true
-    cmds:
-      - . script/bootstrap
+    cmd: . script/bootstrap
     sources:
-      - "{{ .BE_BASE_PATH }}/pyproject.toml"
+      - ./pyproject.toml
     generates:
       - "{{ .VENV_PATH }}/*"
-    dir: backend
   lint:
     desc: "Checks /backend for linting and formatting problems."
     deps: [bootstrap]
     cmd: . script/format.sh
-    dir: backend
     dotenv:
       - ../backend-test.env
   lintfix:
     desc: "Resolves linting and formatting problems in /backend."
     deps: [bootstrap]
     cmd: . script/format.sh
-    dir: backend
     env:
       FIX: 1
     dotenv:
@@ -38,35 +32,30 @@ tasks:
     desc: "Run the test suites."
     deps: [bootstrap]
     cmd: . script/test
-    dir: backend
     dotenv:
       - ../backend-test.env
   start:
     desc: "Starts the backend application."
     deps: [build]
-    env:
-      APP_CONTAINER_NAME: "{{ .APP_CONTAINER_NAME }}"
     cmd: . script/start.sh
-    dir: backend
+    dotenv:
+      - ../backend.env
   stop:
     desc: "Stops the backend application."
-    cmd: docker rm -f {{ .APP_CONTAINER_NAME }}
+    cmd: docker rm -f {{ .APP_CONTAINER_NAME }} {{ .DB_CONTAINER_NAME }}
   logs:
     desc: "Shortcut to Docker container logs"
     cmd: docker logs {{ .APP_CONTAINER_NAME }} -f
   start-db:
     desc: "Provisions a local Postgres database."
     dotenv:
-      - "{{ .DOTENV }}"
+      - ../backend.env
     cmd: . script/provision-db
-    dir: backend
   lock-deps:
     desc: "Locks production and development dependencies"
     deps: [bootstrap]
     cmd: . script/requirements-lock
-    dir: backend
   build:
     desc: "Builds a docker image from /backend"
     cmd: . script/build.sh
-    dir: backend
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -3,5 +3,7 @@ version: '3'
 # See environment-specific taskfiles for commands about
 # that environment.
 includes:
-  be: ./Taskfile.backend.yml
+  be:
+    taskfile: ./Taskfile.backend.yml
+    dir: backend
   fe: ./Taskfile.frontend.yml

--- a/backend-test.env
+++ b/backend-test.env
@@ -1,2 +1,7 @@
 DJANGO_SECRET_KEY="notakey"
 JWT_SIGNING_SECRET="notasecret"
+DB_HOST="rotini_db"
+DB_USER="postgres"
+DB_PASSWORD="postgres"
+DB_PORT=5432
+DB_NAME="postgres"

--- a/backend/rotini/base/settings.py
+++ b/backend/rotini/base/settings.py
@@ -64,11 +64,11 @@ WSGI_APPLICATION = "base.wsgi.application"
 DATABASES = {
     "default": {
         "ENGINE": "django.db.backends.postgresql_psycopg2",
-        "NAME": "postgres",
-        "USER": "postgres",
-        "PASSWORD": "test",
-        "HOST": "docker.host.internal",
-        "PORT": "5432",
+        "NAME": os.environ["DB_NAME"],
+        "USER": os.environ["DB_USER"],
+        "PASSWORD": os.environ["DB_PASSWORD"],
+        "HOST": os.environ["DB_HOST"],
+        "PORT": os.environ["DB_PORT"],
     }
 }
 

--- a/backend/script/build.sh
+++ b/backend/script/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker build -t rotini:dev .

--- a/backend/script/format.sh
+++ b/backend/script/format.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+if [ "$FIX" != "1" ]; then
+    $VENV_BIN/black . --check
+    $VENV_BIN/pylint ./rotini
+    return
+fi
+
+$VENV_BIN/black .
+$VENV_BIN/pylint ./rotini

--- a/backend/script/start.sh
+++ b/backend/script/start.sh
@@ -1,6 +1,21 @@
 #!/bin/bash
 
 docker run \
+    --name $DB_CONTAINER_NAME \
+    -e POSTGRES_PASSWORD=$DATABASE_PASSWORD \
+    -e POSTGRES_USER=$DATABASE_USER \
+    -e POSTGRES_DB=$DATABASE_NAME \
+    -v $DATABASE_STORAGE_PATH:/var/lib/postgresql/data \
+    -p 5432:5432 \
+    -d \
+    postgres:15.4
+
+until [ -n "$(docker exec $DB_CONTAINER_NAME pg_isready | grep accepting)" ]; do
+    echo "Waiting for DB to come alive..."
+    sleep 0.1;
+done;
+
+docker run \
     --detach \
     --publish 8000:8000 \
     --name $APP_CONTAINER_NAME \

--- a/backend/script/start.sh
+++ b/backend/script/start.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+docker run \
+    --detach \
+    --publish 8000:8000 \
+    --name $APP_CONTAINER_NAME \
+    --env-file ../backend.env \
+    rotini:dev


### PR DESCRIPTION
This reduces unneeded complexity in `Taskfile.backend.yml` by...
- Consolidating `be:start` and `be:start-db` under `be:docker:start`; there is no reason for starting one without the other locally.
- Removing redundant paths + env entries that were duplicated or already passed down.
- Extracting build and format logic out of the taskfile into scripts.