### PR TITLE
refactor(taskfiles): remove redundant path to frontend

### DIFF
--- a/Taskfile.frontend.yml
+++ b/Taskfile.frontend.yml
@@ -1,44 +1,34 @@
 version: '3'
 
-env:
-  FE_BASE_PATH: "/{{ .TASKFILE_DIR }}/frontend"
-
 tasks:
   bootstrap:
     internal: true
     cmd: . script/bootstrap
     sources:
-      - "{{ .FE_BASE_PATH }}/yarn.lock"
+      - "{{ .TASKFILE_DIR }}/yarn.lock"
     generates:
-      - "{{ .FE_BASE_PATH }}/.yarn/*"
-    dir: frontend
+      - "{{ .TASKFILE_DIR }}/.yarn/*"
   start:
     desc: "Starts the frontend application."
     deps: [bootstrap]
     cmd: yarn start
-    dir: frontend
   build:
     desc: "Build the app."
     deps: [bootstrap]
     cmd: yarn build
-    dir: frontend
   test:
     desc: "Runs the frontend test suite."
     deps: [bootstrap]
     cmd: yarn test {{ .CLI_ARGS }}
-    dir: frontend
   lint:
     desc: "Checks lint and formatting."
     deps: [bootstrap]
     cmd: yarn lint
-    dir: frontend
   lintfix:
     desc: "Fixes lint and formatting."
     deps: [bootstrap]
     cmd: yarn lint:fix
-    dir: frontend
   typecheck:
     desc: "Validates types."
     deps: [bootstrap]
     cmd: yarn typecheck
-    dir: frontend

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -6,4 +6,6 @@ includes:
   be:
     taskfile: ./Taskfile.backend.yml
     dir: backend
-  fe: ./Taskfile.frontend.yml
+  fe:
+    taskfile: ./Taskfile.frontend.yml
+    dir: frontend


### PR DESCRIPTION
Similar to #60, some redundant paths were included in `Taskfile.frontend.yml`, this removes that to avoid needless duplication and make the file easier to read.