### PR TITLE
fix(taskfiles): resolve naming typo in be:docker:start deps

### DIFF
--- a/Taskfile.backend.yml
+++ b/Taskfile.backend.yml
@@ -40,7 +40,7 @@ tasks:
     cmd: . script/requirements-lock
   docker:start:
     desc: "Starts the backend application."
-    deps: [build]
+    deps: [docker:build]
     cmd: . script/start.sh
     dotenv:
       - ../backend.env


### PR DESCRIPTION
## Description

Resolves a regression introduced in #60 where `be:docker:start` erroneously depends on `build`, when it should now depend on `docker:build` to ensure we build images before starting them locally.

## QA

- Started the backend locally.
- :heavy_check_mark: Confirmed that the build+start cycle works as expected.
