### PR TITLE
feat: cleaner frontend routing

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,6 +22,7 @@
     "@parcel/core": "^2.9.3",
     "@parcel/types": "^2.9.3",
     "@testing-library/dom": "^9.3.1",
+    "@testing-library/jest-dom": "^6.1.5",
     "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^14.4.3",
     "@types/jest": "^29.5.3",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -12,6 +12,8 @@ import AsyncTaskContext from "./contexts/AsyncTaskContext"
 import LocationContext, { useLocationContext } from "./contexts/LocationContext"
 import { useOwnFileList } from "./hooks/files"
 
+import { Router, Route } from "./router"
+
 const routeLabels = {
 	ITEM_DETAILS: "item-details",
 }
@@ -30,14 +32,24 @@ const App = () => {
 		<Box sx={{ display: "flex", flexDirection: "column", width: "100%" }}>
 			<NavigationBar />
 			<Box component="main" sx={{ display: "flex", paddingTop: "10px" }}>
-				<Box component="div" sx={{ flexGrow: 1 }}>
-					<FileList data={data} />
-				</Box>
-				{location.label === routeLabels.ITEM_DETAILS ? (
-					<Box component="div" sx={{ flexGrow: 1 }}>
-						<FileDetails itemId={location.params.itemId} />
-					</Box>
-				) : null}
+				<Router>
+					<Route path="/">
+						<Box component="div" sx={{ flexGrow: 1 }}>
+							<FileList data={data} />
+						</Box>
+					</Route>
+					<Route path="/item/:itemId">
+						<>
+							<Box component="div" sx={{ flexGrow: 1 }}>
+								<FileList data={data} />
+							</Box>
+
+							<Box component="div" sx={{ flexGrow: 1 }}>
+								<FileDetails itemId={location.params.itemId} />
+							</Box>
+						</>
+					</Route>
+				</Router>
 			</Box>
 		</Box>
 	)

--- a/frontend/src/contexts/LocationContext.tsx
+++ b/frontend/src/contexts/LocationContext.tsx
@@ -13,6 +13,7 @@ interface Location {
 	params: {
 		[key: string]: string
 	}
+	pattern: string
 }
 
 interface LocationContextData {
@@ -25,6 +26,7 @@ const defaultValue = {
 		path: "",
 		label: "",
 		params: {},
+		pattern: "",
 	},
 	navigate: () => {},
 }
@@ -70,10 +72,15 @@ function deriveLocation(
 		}
 
 		if (collectedParts !== undefined)
-			return { path, label, params: collectedParts }
+			return {
+				path,
+				label,
+				pattern: `/${pattern.join("/")}`,
+				params: collectedParts,
+			}
 	}
 
-	return { path, label: null, params: {} }
+	return { path, pattern: path, label: null, params: {} }
 }
 
 /*

--- a/frontend/src/router/README.md
+++ b/frontend/src/router/README.md
@@ -1,0 +1,23 @@
+# Frontend routing
+
+Frontend routing is handled by two components: `Router` and `Route`.
+
+```tsx
+<Router>
+    <Route path="/">
+        <ComponentA/>
+    </Route>
+    <Route path="/:itemId">
+        <ComponentB/>
+    </Route>
+</Router>
+```
+
+The `Router` acts as a wrapper for any number of `Route` components that define a path and children to be rendered if
+the browser location matches the path pattern. Parameters can be inserted in patterns by using the `:<name>` syntax
+(i.e. `/item/:itemId`).
+
+## Rendering
+
+The `Router` expects exactly one `Route` to match the browser location at any given time. If less or more than one
+match, an error is thrown and can be handled to display an error fallback.

--- a/frontend/src/router/Route.test.tsx
+++ b/frontend/src/router/Route.test.tsx
@@ -1,0 +1,16 @@
+import { render, screen } from "@testing-library/react"
+
+import Route from "./Route"
+
+describe("Route", () => {
+	it("renders its child", () => {
+		render(
+			<Route path="/test">
+				<p data-testid="child">{"Test text"}</p>
+			</Route>,
+		)
+
+		expect(screen.getByText(/test text/i)).toBeDefined()
+		expect(screen.getByTestId("child")).toBeDefined()
+	})
+})

--- a/frontend/src/router/Route.tsx
+++ b/frontend/src/router/Route.tsx
@@ -1,0 +1,12 @@
+import React from "react"
+
+interface RouteProps {
+	children: React.ReactNode
+	path: string
+}
+
+function Route({ children }: RouteProps) {
+	return children
+}
+
+export default Route

--- a/frontend/src/router/Router.test.tsx
+++ b/frontend/src/router/Router.test.tsx
@@ -1,0 +1,73 @@
+import { render, screen } from "@testing-library/react"
+
+import { LocationContext } from "../contexts/LocationContext"
+import Router from "./Router"
+import Route from "./Route"
+
+function renderComponent(component: React.ReactElement) {
+	render(<LocationContext routes={{}}>{component}</LocationContext>)
+}
+
+describe("Router", () => {
+	afterEach(() => {
+		jest.resetAllMocks()
+	})
+
+	it("throws an error if no Route exists for the given location", () => {
+		jest.spyOn(globalThis, "location", "get").mockReturnValue({
+			...globalThis.location,
+			pathname: "/doesnotexist",
+		})
+
+		// Silence the error to avoid logspam in tests.
+		jest.spyOn(console, "error").mockImplementation(() => {})
+
+		expect(() =>
+			renderComponent(
+				<Router>
+					<Route path="/">
+						<p>{"test"}</p>
+					</Route>
+				</Router>,
+			),
+		).toThrow()
+	})
+
+	it("renders the route matching the given location", () => {
+		jest.spyOn(globalThis, "location", "get").mockReturnValue({
+			...globalThis.location,
+			pathname: "/exists",
+		})
+
+		renderComponent(
+			<Router>
+				<Route path="/exists">
+					<p>{"test"}</p>
+				</Route>
+			</Router>,
+		)
+
+		expect(screen.getByText(/test/i)).toBeInTheDocument()
+	})
+
+	it("only renders the route that matches", () => {
+		jest.spyOn(globalThis, "location", "get").mockReturnValue({
+			...globalThis.location,
+			pathname: "/matches",
+		})
+
+		renderComponent(
+			<Router>
+				<Route path="/matches">
+					<p>{"test"}</p>
+				</Route>
+				<Route path="/doesnotmatch">
+					<p>{"notthere"}</p>
+				</Route>
+			</Router>,
+		)
+
+		expect(screen.getByText(/test/i)).toBeInTheDocument()
+		expect(screen.queryByText(/notthere/i)).toBeNull()
+	})
+})

--- a/frontend/src/router/Router.tsx
+++ b/frontend/src/router/Router.tsx
@@ -1,0 +1,31 @@
+import React, { Children } from "react"
+
+import { useLocationContext } from "../contexts/LocationContext"
+
+interface RouterProps {
+	children: React.ReactNode
+}
+
+function Router({ children }: RouterProps) {
+	const { location } = useLocationContext()
+	const routerChildren = React.useMemo(
+		() => Children.toArray(children),
+		[children],
+	)
+
+	const matchingComponents = routerChildren.filter((child) => {
+		if (typeof child !== "object") return false
+
+		const childRoute = child as React.ReactElement
+
+		return childRoute.props.path === location.pattern
+	})
+
+	if (matchingComponents.length !== 1) {
+		throw new Error("Router failed to find what to render.")
+	}
+
+	return matchingComponents[0]
+}
+
+export default Router

--- a/frontend/src/router/index.tsx
+++ b/frontend/src/router/index.tsx
@@ -1,0 +1,4 @@
+import Router from "./Router"
+import Route from "./Route"
+
+export { Router, Route }

--- a/frontend/tests/FileDetails.test.tsx
+++ b/frontend/tests/FileDetails.test.tsx
@@ -103,6 +103,7 @@ describe("FileDetails", () => {
 				path: "",
 				label: null,
 				params: {},
+				pattern: "",
 			},
 			navigate: navigateMock,
 		})

--- a/frontend/tests/testSetup.ts
+++ b/frontend/tests/testSetup.ts
@@ -1,3 +1,5 @@
+import "@testing-library/jest-dom"
+
 // URL.createObjectURL does not exist in jest-jsdom.
 globalThis.URL.createObjectURL = jest
 	.fn()

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -5,6 +5,13 @@ __metadata:
   version: 6
   cacheKey: 8
 
+"@adobe/css-tools@npm:^4.3.1":
+  version: 4.3.2
+  resolution: "@adobe/css-tools@npm:4.3.2"
+  checksum: 9667d61d55dc3b0a315c530ae84e016ce5267c4dd8ac00abb40108dc98e07b98e3090ce8b87acd51a41a68d9e84dcccb08cdf21c902572a9cf9dcaf830da4ae3
+  languageName: node
+  linkType: hard
+
 "@ampproject/remapping@npm:^2.2.0":
   version: 2.2.1
   resolution: "@ampproject/remapping@npm:2.2.1"
@@ -368,6 +375,15 @@ __metadata:
   dependencies:
     regenerator-runtime: ^0.13.11
   checksum: e585338287c4514a713babf4fdb8fc2a67adcebab3e7723a739fc62c79cfda875b314c90fd25f827afb150d781af97bc16c85bfdbfa2889f06053879a1ddb597
+  languageName: node
+  linkType: hard
+
+"@babel/runtime@npm:^7.9.2":
+  version: 7.23.6
+  resolution: "@babel/runtime@npm:7.23.6"
+  dependencies:
+    regenerator-runtime: ^0.14.0
+  checksum: 1a8eaf3d3a103ef5227b60ca7ab5c589118c36ca65ef2d64e65380b32a98a3f3b5b3ef96660fa0471b079a18b619a8317f3e7f03ab2b930c45282a8b69ed9a16
   languageName: node
   linkType: hard
 
@@ -2222,6 +2238,36 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@testing-library/jest-dom@npm:^6.1.5":
+  version: 6.1.5
+  resolution: "@testing-library/jest-dom@npm:6.1.5"
+  dependencies:
+    "@adobe/css-tools": ^4.3.1
+    "@babel/runtime": ^7.9.2
+    aria-query: ^5.0.0
+    chalk: ^3.0.0
+    css.escape: ^1.5.1
+    dom-accessibility-api: ^0.5.6
+    lodash: ^4.17.15
+    redent: ^3.0.0
+  peerDependencies:
+    "@jest/globals": ">= 28"
+    "@types/jest": ">= 28"
+    jest: ">= 28"
+    vitest: ">= 0.32"
+  peerDependenciesMeta:
+    "@jest/globals":
+      optional: true
+    "@types/jest":
+      optional: true
+    jest:
+      optional: true
+    vitest:
+      optional: true
+  checksum: 67f1433c7eb8649db6676df97d1144cf288e2d94c61e89531c05c587b56f2277454c558c97bcca567d5060ebd39caba5ba01d49dc57b3f005837477a401ad113
+  languageName: node
+  linkType: hard
+
 "@testing-library/react@npm:^14.0.0":
   version: 14.0.0
   resolution: "@testing-library/react@npm:14.0.0"
@@ -2642,6 +2688,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"aria-query@npm:^5.0.0":
+  version: 5.3.0
+  resolution: "aria-query@npm:5.3.0"
+  dependencies:
+    dequal: ^2.0.3
+  checksum: 305bd73c76756117b59aba121d08f413c7ff5e80fa1b98e217a3443fcddb9a232ee790e24e432b59ae7625aebcf4c47cb01c2cac872994f0b426f5bdfcd96ba9
+  languageName: node
+  linkType: hard
+
 "array-buffer-byte-length@npm:^1.0.0":
   version: 1.0.0
   resolution: "array-buffer-byte-length@npm:1.0.0"
@@ -2952,6 +3007,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"chalk@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "chalk@npm:3.0.0"
+  dependencies:
+    ansi-styles: ^4.1.0
+    supports-color: ^7.1.0
+  checksum: 8e3ddf3981c4da405ddbd7d9c8d91944ddf6e33d6837756979f7840a29272a69a5189ecae0ff84006750d6d1e92368d413335eab4db5476db6e6703a1d1e0505
+  languageName: node
+  linkType: hard
+
 "chalk@npm:^4.0.0, chalk@npm:^4.1.0":
   version: 4.1.2
   resolution: "chalk@npm:4.1.2"
@@ -3194,6 +3259,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"css.escape@npm:^1.5.1":
+  version: 1.5.1
+  resolution: "css.escape@npm:1.5.1"
+  checksum: f6d38088d870a961794a2580b2b2af1027731bb43261cfdce14f19238a88664b351cc8978abc20f06cc6bbde725699dec8deb6fe9816b139fc3f2af28719e774
+  languageName: node
+  linkType: hard
+
 "csso@npm:^4.2.0":
   version: 4.2.0
   resolution: "csso@npm:4.2.0"
@@ -3339,6 +3411,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"dequal@npm:^2.0.3":
+  version: 2.0.3
+  resolution: "dequal@npm:2.0.3"
+  checksum: 8679b850e1a3d0ebbc46ee780d5df7b478c23f335887464023a631d1b9af051ad4a6595a44220f9ff8ff95a8ddccf019b5ad778a976fd7bbf77383d36f412f90
+  languageName: node
+  linkType: hard
+
 "detect-libc@npm:^1.0.3":
   version: 1.0.3
   resolution: "detect-libc@npm:1.0.3"
@@ -3362,7 +3441,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dom-accessibility-api@npm:^0.5.9":
+"dom-accessibility-api@npm:^0.5.6, dom-accessibility-api@npm:^0.5.9":
   version: 0.5.16
   resolution: "dom-accessibility-api@npm:0.5.16"
   checksum: 005eb283caef57fc1adec4d5df4dd49189b628f2f575af45decb210e04d634459e3f1ee64f18b41e2dcf200c844bc1d9279d80807e686a30d69a4756151ad248
@@ -5230,6 +5309,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lodash@npm:^4.17.15":
+  version: 4.17.21
+  resolution: "lodash@npm:4.17.21"
+  checksum: eb835a2e51d381e561e508ce932ea50a8e5a68f4ebdd771ea240d3048244a8d13658acbd502cd4829768c56f2e16bdd4340b9ea141297d472517b83868e677f7
+  languageName: node
+  linkType: hard
+
 "loose-envify@npm:^1.1.0, loose-envify@npm:^1.4.0":
   version: 1.4.0
   resolution: "loose-envify@npm:1.4.0"
@@ -5374,6 +5460,13 @@ __metadata:
   version: 2.1.0
   resolution: "mimic-fn@npm:2.1.0"
   checksum: d2421a3444848ce7f84bd49115ddacff29c15745db73f54041edc906c14b131a38d05298dae3081667627a59b2eb1ca4b436ff2e1b80f69679522410418b478a
+  languageName: node
+  linkType: hard
+
+"min-indent@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "min-indent@npm:1.0.1"
+  checksum: bfc6dd03c5eaf623a4963ebd94d087f6f4bbbfd8c41329a7f09706b0cb66969c4ddd336abeb587bc44bc6f08e13bf90f0b374f9d71f9f01e04adc2cd6f083ef1
   languageName: node
   linkType: hard
 
@@ -6169,10 +6262,27 @@ __metadata:
   languageName: node
   linkType: hard
 
+"redent@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "redent@npm:3.0.0"
+  dependencies:
+    indent-string: ^4.0.0
+    strip-indent: ^3.0.0
+  checksum: fa1ef20404a2d399235e83cc80bd55a956642e37dd197b4b612ba7327bf87fa32745aeb4a1634b2bab25467164ab4ed9c15be2c307923dd08b0fe7c52431ae6b
+  languageName: node
+  linkType: hard
+
 "regenerator-runtime@npm:^0.13.11, regenerator-runtime@npm:^0.13.7":
   version: 0.13.11
   resolution: "regenerator-runtime@npm:0.13.11"
   checksum: 27481628d22a1c4e3ff551096a683b424242a216fee44685467307f14d58020af1e19660bf2e26064de946bad7eff28950eae9f8209d55723e2d9351e632bbb4
+  languageName: node
+  linkType: hard
+
+"regenerator-runtime@npm:^0.14.0":
+  version: 0.14.1
+  resolution: "regenerator-runtime@npm:0.14.1"
+  checksum: 9f57c93277b5585d3c83b0cf76be47b473ae8c6d9142a46ce8b0291a04bb2cf902059f0f8445dcabb3fb7378e5fe4bb4ea1e008876343d42e46d3b484534ce38
   languageName: node
   linkType: hard
 
@@ -6316,6 +6426,7 @@ __metadata:
     "@parcel/types": ^2.9.3
     "@tanstack/react-query": ^4.32.6
     "@testing-library/dom": ^9.3.1
+    "@testing-library/jest-dom": ^6.1.5
     "@testing-library/react": ^14.0.0
     "@testing-library/user-event": ^14.4.3
     "@types/jest": ^29.5.3
@@ -6620,6 +6731,15 @@ __metadata:
   version: 2.0.0
   resolution: "strip-final-newline@npm:2.0.0"
   checksum: 69412b5e25731e1938184b5d489c32e340605bb611d6140344abc3421b7f3c6f9984b21dff296dfcf056681b82caa3bb4cc996a965ce37bcfad663e92eae9c64
+  languageName: node
+  linkType: hard
+
+"strip-indent@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "strip-indent@npm:3.0.0"
+  dependencies:
+    min-indent: ^1.0.0
+  checksum: 18f045d57d9d0d90cd16f72b2313d6364fd2cb4bf85b9f593523ad431c8720011a4d5f08b6591c9d580f446e78855c5334a30fb91aa1560f5d9f95ed1b4a0530
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

Implements a `react-router`-inspired routing module that facilitates setting up routes based on paths (+patterns).

This also includes substituting the older routing logic with the router.

Now that the application root has better routing options, the downstream components can be refactored to push complexity away from `App`.