### PR TITLE
chore(frontend): resolve imports from src to avoid harder-to-read relative imports

### DIFF
--- a/frontend/src/components/FileListView/FileListView.test.tsx
+++ b/frontend/src/components/FileListView/FileListView.test.tsx
@@ -2,8 +2,8 @@ import { render, screen, waitFor } from "@testing-library/react"
 import { QueryClientProvider, QueryClient } from "@tanstack/react-query"
 import AxiosMockAdapter from "axios-mock-adapter"
 
-import axios from "../../axios"
-import { LocationContext } from "../../contexts/LocationContext"
+import axios from "../axios"
+import { LocationContext } from "contexts/LocationContext"
 import FileListView from "."
 
 const routes = {

--- a/frontend/src/components/FileListView/index.tsx
+++ b/frontend/src/components/FileListView/index.tsx
@@ -2,10 +2,10 @@ import React from "react"
 
 import Box from "@mui/material/Box"
 
-import FileList from "../FileList"
-import FileDetails from "../FileDetails"
-import { useOwnFileList } from "../../hooks/files"
-import { useLocationContext } from "../../contexts/LocationContext"
+import FileList from "components/FileList"
+import FileDetails from "components/FileDetails"
+import { useOwnFileList } from "hooks/files"
+import { useLocationContext } from "contexts/LocationContext"
 
 function FileListView() {
 	const { isLoading, data } = useOwnFileList()

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -3,7 +3,8 @@
         "target": "ESNext",
         "jsx": "react-jsx",
         "module": "commonjs",
-        "rootDir": ".",
+        "baseUrl": "./src",
+        "rootDir": "./src",
         "moduleResolution": "node",
         "allowJs": false,
         "esModuleInterop": true,
@@ -12,5 +13,6 @@
         "noImplicitAny": true,
         "skipLibCheck": true,
         "types": ["jest"]
-    }
+    },
+    "include": ["src"]
 }


### PR DESCRIPTION
Sets up imports from `src` such that relative imports between modules can be migrates to absolute imports.

`FileListView` is converted to validate.