### PR TITLE
build(fe-formatter): migrate rome to biome, apply unsafe fixes

### DIFF
--- a/frontend/biome.json
+++ b/frontend/biome.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://docs.rome.tools/schemas/12.1.3/schema.json",
+	"$schema": "https://biomejs.dev/schemas/1.0.0/schema.json",
 	"organizeImports": {
 		"enabled": false
 	},

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,12 +13,13 @@
   "scripts": {
     "start": "parcel serve src/index.html --no-cache",
     "build": "parcel build src/index.html",
-    "lint": "rome check src *.js --verbose && rome format src *.js --verbose",
-    "lint:fix": "rome check src ./*.js --apply --verbose && rome format src ./*.js --write --verbose",
+    "lint": "biome check src *.js --verbose && biome format src *.js --verbose",
+    "lint:fix": "biome check src ./*.js --apply --verbose && biome format src ./*.js --write --verbose",
     "test": "yarn jest",
     "typecheck": "yarn tsc --noEmit"
   },
   "devDependencies": {
+    "@biomejs/biome": "^1.4.1",
     "@parcel/core": "^2.10.3",
     "@parcel/types": "^2.10.3",
     "@testing-library/dom": "^9.3.3",
@@ -34,7 +35,6 @@
     "jest-environment-jsdom": "^29.7.0",
     "parcel": "^2.10.3",
     "process": "^0.11.10",
-    "rome": "^12.1.3",
     "ts-jest": "^29.1.1",
     "typescript": "^5.3.0"
   }

--- a/frontend/src/components/FileList/index.tsx
+++ b/frontend/src/components/FileList/index.tsx
@@ -107,7 +107,7 @@ function FileList({ data }: FileListProps) {
 				key={`file list item ${itemData.filename}`}
 			/>
 		))
-	}, [dataWithPlaceholders])
+	}, [dataWithPlaceholders, onClickHandler, downloadFile, deleteFile])
 
 	return (
 		<MuiList sx={{ width: "100%", display: "flex", flexDirection: "column" }}>

--- a/frontend/src/components/RegisterView/index.tsx
+++ b/frontend/src/components/RegisterView/index.tsx
@@ -44,7 +44,7 @@ function RegisterView() {
 				value={emailAddress}
 			/>
 		),
-		[emailAddress, setEmailAddress, validateEmail],
+		[emailAddress, setEmailAddress],
 	)
 
 	const passwordField = React.useMemo(
@@ -59,12 +59,12 @@ function RegisterView() {
 				value={password}
 			/>
 		),
-		[setPassword, password, validatePassword],
+		[setPassword, password],
 	)
 
 	const isFormValid = React.useMemo(() => {
 		return validateEmail(emailAddress) && validatePassword(password)
-	}, [emailAddress, password, validatePassword, validateEmail])
+	}, [emailAddress, password])
 
 	const onCreateClick = React.useCallback(() => {
 		if (!isFormValid) return

--- a/frontend/src/contexts/AsyncTaskContext.tsx
+++ b/frontend/src/contexts/AsyncTaskContext.tsx
@@ -38,7 +38,7 @@ function AsyncTaskContext({
 		(task: AsyncTask) => {
 			setAsyncTaskData([...asyncTaskData, task])
 		},
-		[asyncTaskData, setAsyncTaskData],
+		[asyncTaskData],
 	)
 
 	return (

--- a/frontend/src/contexts/LocationContext.tsx
+++ b/frontend/src/contexts/LocationContext.tsx
@@ -114,7 +114,7 @@ export function LocationContext({
 			history.pushState({}, "", path)
 			setLocation(deriveLocation(path, splitUrlPatterns))
 		},
-		[setLocation, deriveLocation, splitUrlPatterns],
+		[splitUrlPatterns],
 	)
 
 	return (

--- a/frontend/src/utils.ts
+++ b/frontend/src/utils.ts
@@ -4,7 +4,7 @@ function byteSizeToUnits(byteSize: number): string {
 	if (byteSize < 1_000_000) return `${(byteSize / 1000).toFixed(2)} kB`
 
 	if (byteSize < 1_000_000_000) return `${(byteSize / 1_000_000).toFixed(2)} mB`
-	else return `${(byteSize / 1_000_000_000).toFixed(2)} gB`
+	return `${(byteSize / 1_000_000_000).toFixed(2)} gB`
 }
 
 export { byteSizeToUnits }

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -425,6 +425,77 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@biomejs/biome@npm:^1.4.1":
+  version: 1.4.1
+  resolution: "@biomejs/biome@npm:1.4.1"
+  dependencies:
+    "@biomejs/cli-darwin-arm64": "npm:1.4.1"
+    "@biomejs/cli-darwin-x64": "npm:1.4.1"
+    "@biomejs/cli-linux-arm64": "npm:1.4.1"
+    "@biomejs/cli-linux-x64": "npm:1.4.1"
+    "@biomejs/cli-win32-arm64": "npm:1.4.1"
+    "@biomejs/cli-win32-x64": "npm:1.4.1"
+  dependenciesMeta:
+    "@biomejs/cli-darwin-arm64":
+      optional: true
+    "@biomejs/cli-darwin-x64":
+      optional: true
+    "@biomejs/cli-linux-arm64":
+      optional: true
+    "@biomejs/cli-linux-x64":
+      optional: true
+    "@biomejs/cli-win32-arm64":
+      optional: true
+    "@biomejs/cli-win32-x64":
+      optional: true
+  bin:
+    biome: bin/biome
+  checksum: fad12f5fdca7fe51f5ebf0cd559cd6ab67a6ffdb6c4b834cbd3221c1e0ca86c5ea80a565cb3bcdba0901f1055a9050db0a399c43e8c3d469cfd8bc31b95a5aca
+  languageName: node
+  linkType: hard
+
+"@biomejs/cli-darwin-arm64@npm:1.4.1":
+  version: 1.4.1
+  resolution: "@biomejs/cli-darwin-arm64@npm:1.4.1"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@biomejs/cli-darwin-x64@npm:1.4.1":
+  version: 1.4.1
+  resolution: "@biomejs/cli-darwin-x64@npm:1.4.1"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@biomejs/cli-linux-arm64@npm:1.4.1":
+  version: 1.4.1
+  resolution: "@biomejs/cli-linux-arm64@npm:1.4.1"
+  conditions: os=linux & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@biomejs/cli-linux-x64@npm:1.4.1":
+  version: 1.4.1
+  resolution: "@biomejs/cli-linux-x64@npm:1.4.1"
+  conditions: os=linux & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@biomejs/cli-win32-arm64@npm:1.4.1":
+  version: 1.4.1
+  resolution: "@biomejs/cli-win32-arm64@npm:1.4.1"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@biomejs/cli-win32-x64@npm:1.4.1":
+  version: 1.4.1
+  resolution: "@biomejs/cli-win32-x64@npm:1.4.1"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@emotion/babel-plugin@npm:^11.11.0":
   version: 11.11.0
   resolution: "@emotion/babel-plugin@npm:11.11.0"
@@ -1999,48 +2070,6 @@ __metadata:
   version: 2.11.8
   resolution: "@popperjs/core@npm:2.11.8"
   checksum: ddd16090cde777aaf102940f05d0274602079a95ad9805bd20bc55dcc7c3a2ba1b99dd5c73e5cc2753c3d31250ca52a67d58059459d7d27debb983a9f552936c
-  languageName: node
-  linkType: hard
-
-"@rometools/cli-darwin-arm64@npm:12.1.3":
-  version: 12.1.3
-  resolution: "@rometools/cli-darwin-arm64@npm:12.1.3"
-  conditions: os=darwin & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"@rometools/cli-darwin-x64@npm:12.1.3":
-  version: 12.1.3
-  resolution: "@rometools/cli-darwin-x64@npm:12.1.3"
-  conditions: os=darwin & cpu=x64
-  languageName: node
-  linkType: hard
-
-"@rometools/cli-linux-arm64@npm:12.1.3":
-  version: 12.1.3
-  resolution: "@rometools/cli-linux-arm64@npm:12.1.3"
-  conditions: os=linux & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"@rometools/cli-linux-x64@npm:12.1.3":
-  version: 12.1.3
-  resolution: "@rometools/cli-linux-x64@npm:12.1.3"
-  conditions: os=linux & cpu=x64
-  languageName: node
-  linkType: hard
-
-"@rometools/cli-win32-arm64@npm:12.1.3":
-  version: 12.1.3
-  resolution: "@rometools/cli-win32-arm64@npm:12.1.3"
-  conditions: os=win32 & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"@rometools/cli-win32-x64@npm:12.1.3":
-  version: 12.1.3
-  resolution: "@rometools/cli-win32-x64@npm:12.1.3"
-  conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
 
@@ -6407,39 +6436,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rome@npm:^12.1.3":
-  version: 12.1.3
-  resolution: "rome@npm:12.1.3"
-  dependencies:
-    "@rometools/cli-darwin-arm64": "npm:12.1.3"
-    "@rometools/cli-darwin-x64": "npm:12.1.3"
-    "@rometools/cli-linux-arm64": "npm:12.1.3"
-    "@rometools/cli-linux-x64": "npm:12.1.3"
-    "@rometools/cli-win32-arm64": "npm:12.1.3"
-    "@rometools/cli-win32-x64": "npm:12.1.3"
-  dependenciesMeta:
-    "@rometools/cli-darwin-arm64":
-      optional: true
-    "@rometools/cli-darwin-x64":
-      optional: true
-    "@rometools/cli-linux-arm64":
-      optional: true
-    "@rometools/cli-linux-x64":
-      optional: true
-    "@rometools/cli-win32-arm64":
-      optional: true
-    "@rometools/cli-win32-x64":
-      optional: true
-  bin:
-    rome: bin/rome
-  checksum: a0021342ea339279aeed0111997144e2b703451b9a73b3bd21150408eb1c2e0563e8f59ea2f2792b261c9fe4f97f269759a9c66fc2cab87f4ffe5fb391120f77
-  languageName: node
-  linkType: hard
-
 "root-workspace-0b6124@workspace:.":
   version: 0.0.0-use.local
   resolution: "root-workspace-0b6124@workspace:."
   dependencies:
+    "@biomejs/biome": "npm:^1.4.1"
     "@emotion/react": "npm:^11.11.1"
     "@emotion/styled": "npm:^11.11.0"
     "@mui/icons-material": "npm:^5.14.1"
@@ -6463,7 +6464,6 @@ __metadata:
     process: "npm:^0.11.10"
     react: "npm:^18.2.0"
     react-dom: "npm:^18.2.0"
-    rome: "npm:^12.1.3"
     ts-jest: "npm:^29.1.1"
     typescript: "npm:^5.3.0"
   languageName: unknown


### PR DESCRIPTION
Rome has been archived as of [August 2023](https://github.com/rome/tools), with its successor being Biome. This migrates the frontend tooling from Rome to Biome and applies any fixes that might be made necessary by the new rules that were introduced since the last update.