### PR TITLE
fix: ci setting python version correctly

### DIFF
--- a/.github/workflows/backend-pipeline.yml
+++ b/.github/workflows/backend-pipeline.yml
@@ -23,43 +23,18 @@ jobs:
     name: Setup
     steps:
       - uses: actions/checkout@v4
-      - name: get-python-version
-        run: |
-          echo "python_version=$(cat .python-version)" >> $GITHUB_OUTPUT
-      - uses: actions/setup-python@v5
+      - uses: ./.github/workflows/setup-backend-environment
         with:
-          python-version: ${{ steps.get-python-version.outputs.python_version }}
-      - uses: actions/cache@v3
-        id: cache-restore
-        with:
-          path: |
-            backend/.venv
-          key: ${{ runner.os }}-${{ hashFiles('**/requirements*.txt') }}-${{ steps.get-python-version.outputs.python_version }}
-      - name: Install dependencies
-        if: steps.cache-restore.outputs.cache-hit != 'true'
-        run: . script/bootstrap
+          task-version: ${{ inputs.task-version }}
   lint:
     runs-on: ubuntu-latest
     name: Lint
     needs: setup
     steps:
       - uses: actions/checkout@v4
-      - name: get-python-version
-        run: |
-          echo "python_version=$(cat .python-version)" >> $GITHUB_OUTPUT
-      - uses: actions/setup-python@v5
+      - uses: ./.github/workflows/setup-backend-environment
         with:
-          python-version: ${{ steps.get-python-version.outputs.python_version }}
-      - name: Setup Task
-        uses: arduino/setup-task@v1
-        with:
-          version: ${{ inputs.task-version }}
-      - uses: actions/cache@v3
-        id: cache-restore
-        with:
-          path: |
-            backend/.venv
-          key: ${{ runner.os }}-${{ hashFiles('**/requirements*.txt') }}-${{ steps.get-python-version.outputs.python_version }}
+          task-version: ${{ inputs.task-version }}
       - name: Lint
         run: |
           task be:lint
@@ -69,22 +44,9 @@ jobs:
     needs: setup
     steps:
       - uses: actions/checkout@v4
-      - name: get-python-version
-        run: |
-          echo "python_version=$(cat .python-version)" >> $GITHUB_OUTPUT
-      - uses: actions/setup-python@v5
+      - uses: ./.github/workflows/setup-backend-environment
         with:
-          python-version: ${{ steps.get-python-version.outputs.python_version }}
-      - name: Setup Task
-        uses: arduino/setup-task@v1
-        with:
-          version: ${{ inputs.task-version }}
-      - uses: actions/cache@v3
-        id: cache-restore
-        with:
-          path: |
-            backend/.venv
-          key: ${{ runner.os }}-${{ hashFiles('**/requirements*.txt') }}-${{ steps.get-python-version.outputs.python_version }}
+          task-version: ${{ inputs.task-version }}
       - name: Test
         run: |
           task be:test

--- a/.github/workflows/setup-backend-environment/action.yml
+++ b/.github/workflows/setup-backend-environment/action.yml
@@ -1,0 +1,36 @@
+#
+# Standardized backend CI environment setup.
+#
+# This is expected to run before any step logic is executed.
+#
+
+name: 'Setup Backend Environment'
+inputs:
+  task-version:
+    required: true
+outputs:
+  python-version:
+    value: ${{ steps.setup-python.outputs.python-version }}
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/checkout@v4
+    - name: Setup Task
+      uses: arduino/setup-task@v1
+      with:
+        version: ${{ inputs.task-version }}
+    - uses: actions/setup-python@v5
+      id: setup-python
+      with:
+        python-version-file: './backend/pyproject.toml'
+    - uses: actions/cache@v3
+      id: cache-restore
+      with:
+        path: |
+          backend/.venv
+        key: ${{ runner.os }}-${{ hashFiles('**/requirements*.txt') }}-${{ steps.setup-python.outputs.python-version }}
+    - name: Install dependencies
+      if: steps.cache-restore.outputs.cache-hit != 'true'
+      run: . script/bootstrap
+      working-directory: backend
+      shell: bash

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ lerna-debug.log*
 
 # Env files
 backend.env
+.python-version
 
 .task
 bin

--- a/Taskfile.backend.yml
+++ b/Taskfile.backend.yml
@@ -5,11 +5,12 @@ env:
   VENV_BIN: "{{ .VENV_PATH }}/bin"
   APP_CONTAINER_NAME: "rotini_app"
   DB_CONTAINER_NAME: "rotini_db"
+  SHELL: /bin/bash
 
 tasks:
   bootstrap:
     internal: true
-    cmd: . script/bootstrap
+    cmd: $SHELL script/bootstrap
     sources:
       - ./pyproject.toml
     generates:
@@ -23,7 +24,7 @@ tasks:
   lintfix:
     desc: "Resolves linting and formatting problems in /backend."
     deps: [bootstrap]
-    cmd: . script/format.sh
+    cmd: $SHELL script/format.sh
     env:
       FIX: 1
     dotenv:
@@ -31,17 +32,17 @@ tasks:
   test:
     desc: "Run the test suites."
     deps: [bootstrap]
-    cmd: . script/test
+    cmd: $SHELL script/test
     dotenv:
       - ../backend-test.env
   lock-deps:
     desc: "Locks production and development dependencies"
     deps: [bootstrap]
-    cmd: . script/requirements-lock
+    cmd: $SHELL script/requirements-lock
   docker:start:
     desc: "Starts the backend application."
     deps: [docker:build]
-    cmd: . script/start.sh
+    cmd: $SHELL script/start.sh
     dotenv:
       - ../backend.env
   docker:stop:
@@ -52,5 +53,5 @@ tasks:
     cmd: docker logs {{ .APP_CONTAINER_NAME }} -f
   docker:build:
     desc: "Builds a docker image from /backend"
-    cmd: . script/build.sh
+    cmd: $SHELL script/build.sh
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -42,7 +42,6 @@ django-settings-module="base.settings"
 [tool.pylint.main]
 ignore-paths = ["^\\\\.venv|^/.venv"]
 ignore-patterns = ["^\\.#"]
-py-version = "3.11"
 source-roots = ["rotini"]
 suggestion-mode = true
 


### PR DESCRIPTION
This resolves issues around CI environment setup.

Previously, CI was not correctly setting up the environment and ran tests / linting on py3.10. Ensuring that Python was correctly set up in CI uncovered another issue around Taskfiles and the shells they run on (hence the explicit `$SHELL` prefix on task shell commands).

To tidy things up, the backend CI env setup was isolated to its own local action so it can be reused across the board - this includes python, go-task and venv setup (caching incl.).