### PR TITLE
chore: automerge frontend patch releases

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -8,12 +8,20 @@
     {
         "description": "Backend-related updates",
         "matchFileNames": ["backend/**"],
-        "labels": ["backend"]
+        "addLabels": ["backend"]
     },
     {
         "description": "Frontend-related updates",
         "matchFileNames": ["frontend/**"],
-        "labels": ["frontend"]
+        "addLabels": ["frontend"]
+    },
+    {
+        "description": "Automerge patch updates in frontend packages",
+        "matchFileNames": ["frontend/**"],
+        "labels": ["frontend", "automerge"],
+        "matchUpdateTypes": ["patch"],
+        "addLabels": ["automerge"],
+        "automerge": true
     }
   ],
   "reviewers": ["mcataford"]


### PR DESCRIPTION
# Description

This sets up Renovate to automerge patch releases on frontend dependencies. The dependencies are vetted when added and shouldn't be of concern. If any dependency is deemed not trustworthy enough to merge its patch releases automatically, a rule should exist for it _or_ it should be migrated off of.

# QA

Nil.
