### PR TITLE
chore(fe-tooling): ignore build artifacts when linting

### DIFF
--- a/frontend/biome.json
+++ b/frontend/biome.json
@@ -1,6 +1,11 @@
 {
 	"$schema": "https://biomejs.dev/schemas/1.0.0/schema.json",
-	"organizeImports": {
+	"files": {
+        "ignore": [
+            "**/dist/**"
+        ]
+    },
+    "organizeImports": {
 		"enabled": false
 	},
 	"linter": {


### PR DESCRIPTION
# Description

Running `task fe:lint` was catching on any `**/dist/**` artifacts generated by Vite. This fixes that by ignoring dist directories.

# QA

- :heavy_check_mark: Ran `task fe:lint fe:lintfix` and verified that the artifacts are ignored even if present.