### PR TITLE
build(git): add pre-commit to selective format, typecheck

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -15,4 +15,8 @@ if [[ -z $BIN_MATCH ]]; then
     export PATH=$PATH:$BIN_PATH
 fi
 
+echo "Adding pre-commit hook"
+cp ./script/pre-commit ./.git/hooks
+chmod +x ./.git/hooks/pre-commit
+
 echo "All done!"

--- a/script/pre-commit
+++ b/script/pre-commit
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+TASKS=""
+
+if [ -n "$(git diff --cached --name-only origin/main -- ./frontend)" ]; then
+    TASKS="$TASKS fe:lint fe:typecheck"
+fi
+
+if [ -n "$(git diff --cached --name-only origin/main -- ./backend)" ]; then
+    TASKS="$TASKS be:lint"
+fi
+
+if [ -n "$TASKS" ]; then
+    echo "Running $TASKS"
+    task $TASKS
+fi


### PR DESCRIPTION
# Description

This adds a rudimentary pre-commit hook to format and typecheck backend and frontend changes on commit to avoid anything slipping in and needlessly failing in CI.

The approach was chosen over canned solutions because extra dependencies aren't needed to do something that git already covers.

# QA

- :heavy_check_mark: Tried to commit changes in `frontend` and `backend` to ensure that hook runs as expected.