### PR TITLE
fix(fe-auth): add awareness of authentication in frontend

### DIFF
--- a/backend/rotini/identity/serializers.py
+++ b/backend/rotini/identity/serializers.py
@@ -1,0 +1,18 @@
+from rest_framework import serializers
+from django.contrib.auth import get_user_model
+
+
+class UserSerializer(serializers.ModelSerializer):
+    """Serializes an instance of AuthUser"""
+
+    class Meta:
+        model = get_user_model()
+        fields = [
+            "id",
+            "username",
+            "first_name",
+            "last_name",
+            "email",
+            "date_joined",
+            "last_login",
+        ]

--- a/frontend/src/components/LoginView/index.tsx
+++ b/frontend/src/components/LoginView/index.tsx
@@ -1,5 +1,4 @@
 import React from "react"
-import { useMutation } from "@tanstack/react-query"
 
 import Typography from "@mui/material/Typography"
 import Box from "@mui/material/Box"
@@ -11,29 +10,14 @@ import Button from "@mui/material/Button"
 import Link from "@mui/material/Link"
 import Alert from "@mui/material/Alert"
 
+import { useLogin } from "../../queries/auth"
 import axiosWithDefaults from "../../axios"
 import TextInput from "../TextInput"
-import { useLocationContext } from "../../contexts/LocationContext"
 
 function LoginView() {
 	const [emailAddress, setEmailAddress] = React.useState<string>("")
 	const [password, setPassword] = React.useState<string>("")
-	const { navigate } = useLocationContext()
-
-	const { mutate, isError, isPending } = useMutation({
-		mutationFn: async ({
-			email,
-			password,
-		}: { email: string; password: string }) => {
-			return axiosWithDefaults.post("/auth/session/", {
-				username: email,
-				password,
-			})
-		},
-		onSuccess: (response) => {
-			navigate("/")
-		},
-	})
+	const { login, isError, isPending } = useLogin()
 
 	const emailField = React.useMemo(
 		() => (
@@ -68,8 +52,8 @@ function LoginView() {
 	const onLoginClick = React.useCallback(() => {
 		if (!isFormValid) return
 
-		mutate({ email: emailAddress, password })
-	}, [mutate, emailAddress, password, isFormValid])
+		login({ email: emailAddress, password })
+	}, [login, emailAddress, password, isFormValid])
 
 	return (
 		<Box sx={{ display: "flex", justifyContent: "center", width: "100%" }}>

--- a/frontend/src/components/NavigationBar/NavigationBar.test.tsx
+++ b/frontend/src/components/NavigationBar/NavigationBar.test.tsx
@@ -24,13 +24,26 @@ function renderComponent() {
 
 describe("NavigationBar", () => {
 	describe("Upload functionality", () => {
-		it("Renders the upload button", () => {
+		it("does not render the upload button if not authenticated", () => {
+			const axiosMock = getAxiosMockAdapter()
+
+			axiosMock.onGet("/auth/user/").reply(403)
 			renderComponent()
-			expect(screen.queryByText("Upload file")).toBeInTheDocument()
+			expect(screen.queryByText("Upload file")).not.toBeInTheDocument()
 		})
 
+		it("renders the upload button if authenticated", async () => {
+			const axiosMock = getAxiosMockAdapter()
+
+			axiosMock.onGet("/auth/user/").reply(200)
+			renderComponent()
+			await waitFor(() =>
+				expect(screen.queryByText("Upload file")).toBeInTheDocument(),
+			)
+		})
 		it("Clicking the upload button and selecting a file POSTs the file", async () => {
 			const axiosMock = getAxiosMockAdapter()
+			axiosMock.onGet("/auth/user/").reply(200)
 			const expectedUrlPattern = new RegExp("/files/$")
 			axiosMock.onPost(expectedUrlPattern).reply(200, {
 				id: "b61bf93d-a9db-473e-822e-a65003b1b7e3",
@@ -40,6 +53,9 @@ describe("NavigationBar", () => {
 			})
 
 			const { user, container } = renderComponent()
+			await waitFor(() =>
+				expect(screen.queryByText("Upload file")).toBeInTheDocument(),
+			)
 			const uploadButton = screen.getByText("Upload file")
 			const mockFile = new File(["test"], "test.txt", { type: "text/plain" })
 
@@ -60,16 +76,27 @@ describe("NavigationBar", () => {
 	})
 
 	describe("Log out", () => {
-		it("renders a logout button", () => {
+		it("does not render the upload button if not authenticated", () => {
+			const axiosMock = getAxiosMockAdapter()
+
+			axiosMock.onGet("/auth/user/").reply(403)
 			renderComponent()
+			expect(screen.queryByText("Log out")).not.toBeInTheDocument()
+		})
 
-			expect(screen.queryByText("Log out")).toBeInTheDocument()
+		it("renders the upload button if authenticated", async () => {
+			const axiosMock = getAxiosMockAdapter()
 
-			const button = screen.getByText("Log out")
+			axiosMock.onGet("/auth/user/").reply(200)
+			renderComponent()
+			await waitFor(() =>
+				expect(screen.queryByText("Log out")).toBeInTheDocument(),
+			)
 		})
 
 		it("sends a logout request and redirects to the login page when logging out", async () => {
 			const axiosMock = getAxiosMockAdapter()
+			axiosMock.onGet("/auth/user/").reply(200)
 			axiosMock.onDelete("/auth/session/").reply(204)
 			const mockNavigate = vi.fn()
 			const mockLocationHook = vi
@@ -85,7 +112,9 @@ describe("NavigationBar", () => {
 				}))
 
 			const { user } = renderComponent()
-
+			await waitFor(() =>
+				expect(screen.queryByText("Log out")).toBeInTheDocument(),
+			)
 			const logoutButton = screen.getByText("Log out")
 
 			await user.click(logoutButton)

--- a/frontend/src/components/NavigationBar/index.tsx
+++ b/frontend/src/components/NavigationBar/index.tsx
@@ -9,6 +9,7 @@ import UploadIcon from "@mui/icons-material/Upload"
 
 import { useFileMutations } from "../../hooks/files"
 import { useLogout } from "../../queries/auth"
+import { useCurrentUser } from "../../queries/user"
 
 function UploadFileButton() {
 	const fileRef = useRef(null)
@@ -47,6 +48,21 @@ function UploadFileButton() {
 
 function NavigationBar() {
 	const { logout } = useLogout()
+	const { currentUser, isAuthenticated } = useCurrentUser()
+
+	const buttons = isAuthenticated ? (
+		<>
+			<UploadFileButton />
+			<Button
+				color="inherit"
+				onClick={() => {
+					logout()
+				}}
+			>
+				Log out
+			</Button>
+		</>
+	) : null
 
 	return (
 		<AppBar position="sticky" sx={{ display: "flex" }}>
@@ -54,15 +70,7 @@ function NavigationBar() {
 				<Typography variant="h6" component="div" sx={{ flexGrow: 1 }}>
 					Rotini
 				</Typography>
-				<UploadFileButton />
-				<Button
-					color="inherit"
-					onClick={() => {
-						logout()
-					}}
-				>
-					Log out
-				</Button>
+				{buttons}
 			</Toolbar>
 		</AppBar>
 	)

--- a/frontend/src/queries/user.test.tsx
+++ b/frontend/src/queries/user.test.tsx
@@ -1,0 +1,54 @@
+import React from "react"
+import { describe, it, expect, vi } from "vitest"
+import { renderHook, waitFor } from "@testing-library/react"
+import { QueryClientProvider, QueryClient } from "@tanstack/react-query"
+import AxiosMockAdapter from "axios-mock-adapter"
+
+import axiosWithDefaults from "../axios"
+import { useCurrentUser } from "./user"
+
+function WithProviders({ children }: { children: React.ReactNode }) {
+	return (
+		<QueryClientProvider client={new QueryClient()}>
+			{children}
+		</QueryClientProvider>
+	)
+}
+
+describe("useCurrentUser", () => {
+	it("sends a request to the currentUser api", async () => {
+		const axios = new AxiosMockAdapter(axiosWithDefaults)
+
+		axios.onGet("/auth/user/").reply(204)
+
+		const { result } = renderHook(() => useCurrentUser(), {
+			wrapper: WithProviders,
+		})
+
+		await waitFor(() => expect(axios.history.get.length).toEqual(1))
+
+		const getRequest = axios.history.get[0]
+
+		expect(getRequest.url).toEqual("/auth/user/")
+	})
+
+	it.each`
+		isAuthenticated | returnCode
+		${false}        | ${403}
+		${true}         | ${200}
+	`(
+		"sets isAuthenticated ($isAuthenticated) when the api returns $returnCode",
+		async ({ isAuthenticated, returnCode }) => {
+			const axios = new AxiosMockAdapter(axiosWithDefaults)
+
+			axios.onGet("/auth/user/").reply(returnCode, { status: returnCode })
+
+			const { result } = renderHook(() => useCurrentUser(), {
+				wrapper: WithProviders,
+			})
+
+			await waitFor(() => expect(result.current.isLoading).toBe(false))
+			expect(result.current.isAuthenticated).toBe(isAuthenticated)
+		},
+	)
+})

--- a/frontend/src/queries/user.ts
+++ b/frontend/src/queries/user.ts
@@ -1,0 +1,28 @@
+import { useQuery } from "@tanstack/react-query"
+
+import axiosWithDefaults from "../axios"
+
+/*
+ * Current user data fetch.
+ *
+ * This hook fetches data about the currently-authenticated user
+ * if there is one and returns basic information about them as well
+ * as a `isAuthenticated` flag that determines if we are logged in or not.
+ */
+function useCurrentUser() {
+	const { data, isLoading, isError, isSuccess } = useQuery({
+		queryKey: ["current-user"],
+		queryFn: async () => {
+			return axiosWithDefaults.get("/auth/user/")
+		},
+		retry: false,
+	})
+
+	const isAuthenticated = !isLoading && isSuccess && data.status === 200
+
+	return { currentUser: data, isSuccess, isError, isLoading, isAuthenticated }
+}
+
+export { useCurrentUser }
+
+export default { useCurrentUser }


### PR DESCRIPTION
# Description

Previously, the application was not aware of whether a user was authenticated or not. This led to awkward UI like "Logout" / "Upload File" being present in the navigation bar despite the user not being logged in (i.e. in the login page).

This fixes that by introducing a `useCurrentUser` query hook and API that can provide a check to frontend concerns re:whether the user is authenticated or not.

Additional refactors:
- The `useLogin` query hook is now in `queries/auth` instead of being embedded in the `LoginView`.

# QA

- :heavy_check_mark: Logged in, verified that the action buttons (Upload File / Logout) appear after success;
- :heavy_check_mark: Logged out, verified that the action buttons disappear after success;
