### PR TITLE
perf(be): use gzip middleware for eligible responses

### DIFF
--- a/backend/rotini/base/settings.py
+++ b/backend/rotini/base/settings.py
@@ -35,6 +35,7 @@ INSTALLED_APPS = [
 ]
 
 MIDDLEWARE = [
+    "django.middleware.gzip.GZipMiddleware",
     "django.middleware.security.SecurityMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "corsheaders.middleware.CorsMiddleware",


### PR DESCRIPTION
# Description

This includes the Django Gzip middleware to minimize the size of eligible responses.

# QA

- :heavy_check_mark: Verified that `content-encoding: gzip` is present on responses >=500B.
