### PR TITLE
build(containers): default to podman + update references

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ Note that this is the preferred way to running any tooling-related task within t
 environment. Individual scripts exist under `/{frontend,backend}/script` but generally assume that they will be called
 through `task` to inject some environment variables.
 
+The project uses [Podman](https://podman.io/) as a default container manager, but is Docker-compatible
+(`Taskfile.backend.yml` can be made to specify `CONTAINER_MANAGER="docker"` to use it).
+
 #### Formatting
 
 Formatting in either frontend or backend environment can be done via `task {fe,be}:lint`. Applying fixes is available
@@ -37,7 +40,7 @@ Test suites can be executed by environment via `task {fe,be}:test`.
 The application requires a Postgres database instance to be made available to the backend. Setting up a local database
 is handled by the backend start command.
 
-Starting the backend (including a database) and frontend applications can be done via `task be:docker:start` and `task fe:start`.
+Starting the backend (including a database) and frontend applications can be done via `task be:container:start` and `task fe:start`.
 
 See the README files of each of those environments ([backend](./backend/README.md), [frontend](./frontend/README.md)) for specific requirements around `*.env` files that aren't committed with the code.
 

--- a/Taskfile.backend.yml
+++ b/Taskfile.backend.yml
@@ -6,6 +6,7 @@ env:
   APP_CONTAINER_NAME: "rotini_app"
   DB_CONTAINER_NAME: "rotini_db"
   SHELL: /bin/bash
+  CONTAINER_MANAGER: "podman"
 
 tasks:
   bootstrap:
@@ -32,26 +33,28 @@ tasks:
   test:
     desc: "Run the test suites."
     deps: [bootstrap]
-    cmd: $SHELL script/test {{ .CLI_ARGS }}
+    cmd: $SHELL script/test.sh {{ .CLI_ARGS }}
     dotenv:
       - ../backend-test.env
   lock-deps:
     desc: "Locks production and development dependencies"
     deps: [bootstrap]
     cmd: $SHELL script/requirements-lock
-  docker:start:
+  container:start:
     desc: "Starts the backend application."
-    deps: [docker:build]
+    deps: [container:build]
     cmd: $SHELL script/start.sh
     dotenv:
       - ../backend.env
-  docker:stop:
+  container:stop:
     desc: "Stops the backend application."
-    cmd: docker rm -f {{ .APP_CONTAINER_NAME }} {{ .DB_CONTAINER_NAME }}
-  docker:logs:
-    desc: "Shortcut to Docker container logs"
-    cmd: docker logs {{ .APP_CONTAINER_NAME }} -f
-  docker:build:
-    desc: "Builds a docker image from /backend"
+    cmds:
+      - "{{ .CONTAINER_MANAGER }} rm -f {{ .APP_CONTAINER_NAME }}"
+      - "{{ .CONTAINER_MANAGER }} rm -f {{ .DB_CONTAINER_NAME }}"
+  container:logs:
+    desc: "Shortcut to container container logs"
+    cmd: "{{ .CONTAINER_MANAGER }} logs -f {{ .APP_CONTAINER_NAME }}"
+  container:build:
+    desc: "Builds a container image from /backend"
     cmd: $SHELL script/build.sh
 

--- a/backend/script/build.sh
+++ b/backend/script/build.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-docker build -t rotini:dev .
+$CONTAINER_MANAGER build -t rotini:dev .

--- a/backend/script/start.sh
+++ b/backend/script/start.sh
@@ -1,24 +1,24 @@
 #!/bin/bash
 
-docker network create rotini-local || echo "Network already exists"
+$CONTAINER_MANAGER network create rotini-local || echo "Network already exists"
 
-docker run \
+$CONTAINER_MANAGER run \
     --name $DB_CONTAINER_NAME \
     -e POSTGRES_PASSWORD=$DB_PASSWORD \
     -e POSTGRES_USER=$DB_USER \
     -e POSTGRES_DB=$DB_NAME \
-    -v $DATABASE_STORAGE_PATH:/var/lib/postgresql/data \
+    -v $DATABASE_STORAGE_PATH:/var/lib/postgresql/data:Z \
     -p 5432:5432 \
     --network rotini-local \
     -d \
-    postgres:15.4
+    postgres:15
 
-until [ -n "$(docker exec $DB_CONTAINER_NAME pg_isready | grep accepting)" ]; do
+until [ -n "$($CONTAINER_MANAGER exec $DB_CONTAINER_NAME pg_isready | grep accepting)" ]; do
     echo "Waiting for DB to come alive..."
     sleep 0.1;
 done;
 
-docker run \
+$CONTAINER_MANAGER run \
     --detach \
     --publish 8000:8000 \
     --name $APP_CONTAINER_NAME \


### PR DESCRIPTION
# Description

This generalizes the usage of `docker` such that `podman` can easily be substituted for it, then makes `podman` the default container manager (while leaving it configurable enough to allow switching back to `docker` if need be).

## Minor changes

- Commands that featured `docker` in their namespace were updated to have `container` instead (i.e. `task be:docker:start` becomes `task be:container:start`);
- `backend/script/test` was renamed to `backend/script/test.sh` for consistency;

# QA

- :heavy_check_mark: Started and stopped backend containers via `be:container:start` and `:stop`.
- :heavy_check_mark: Ran the backend test suite via `be:test`.
- :heavy_check_mark: Audited CI definitions for references to updated commands.